### PR TITLE
Impl event newHeads

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -230,6 +230,8 @@ func (c *Config) getNodeConfig() (*node.Config, error) {
 		HTTPCors:         n.HTTPCors,
 		HTTPVirtualHosts: n.HTTPVirtualHosts,
 		HTTPModules:      n.HTTPModules,
+		WSHost:           n.WSHost,
+		WSPort:           n.WSPort,
 		MainChainConfig:  node.MainChainConfig{},
 		DualChainConfig:  node.DualChainConfig{},
 		PeerProxyIP:      "",

--- a/cmd/types.go
+++ b/cmd/types.go
@@ -43,6 +43,8 @@ type (
 		HTTPModules      []string `yaml:"HTTPModules"`
 		HTTPVirtualHosts []string `yaml:"HTTPVirtualHosts"`
 		HTTPCors         []string `yaml:"HTTPCors"`
+		WSHost           string   `yaml:"WSHost"`
+		WSPort           int      `yaml:"WSPort"`
 		Metrics          uint     `yaml:"Metrics"`
 		Genesis          *Genesis `yaml:"Genesis,omitempty"`
 	}

--- a/mainchain/kardia_service.go
+++ b/mainchain/kardia_service.go
@@ -243,6 +243,12 @@ func (s *KardiaService) APIs() []rpc.API {
 			Service:   NewPublicAccountAPI(s),
 			Public:    true,
 		},
+		{
+			Namespace: "kai",
+			Version:   "1.0",
+			Service:   NewPublicFilterAPI(s),
+			Public:    true,
+		},
 	}
 }
 

--- a/mainchain/kardia_service.go
+++ b/mainchain/kardia_service.go
@@ -232,6 +232,12 @@ func (s *KardiaService) APIs() []rpc.API {
 			Public:    true,
 		},
 		{
+			Namespace: "kai",
+			Version:   "1.0",
+			Service:   NewPublicFilterAPI(s),
+			Public:    true,
+		},
+		{
 			Namespace: "tx",
 			Version:   "1.0",
 			Service:   NewPublicTransactionAPI(s),

--- a/mainchain/kardia_service.go
+++ b/mainchain/kardia_service.go
@@ -249,12 +249,6 @@ func (s *KardiaService) APIs() []rpc.API {
 			Service:   NewPublicAccountAPI(s),
 			Public:    true,
 		},
-		{
-			Namespace: "kai",
-			Version:   "1.0",
-			Service:   NewPublicFilterAPI(s),
-			Public:    true,
-		},
 	}
 }
 


### PR DESCRIPTION
Problems: Currently, the client needs to 'spam' RPC request to a node to check if a new block was generated. 

This PR deal with:
- Allow clients to connect to a node through WebSocket.
- Add new API for clients to subscribe 'newHeads' event, which notify clients when node received a new block.
