### PR TITLE
Minor fix API, tx pool and bloom filters

### DIFF
--- a/lib/crypto/crypto.go
+++ b/lib/crypto/crypto.go
@@ -25,6 +25,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"hash"
 	"io"
 	"io/ioutil"
 	"math/big"
@@ -41,6 +42,14 @@ var (
 )
 
 var errInvalidPubkey = errors.New("invalid secp256k1 public key")
+
+// keccakState wraps sha3.state. In addition to the usual hash methods, it also supports
+// Read to get a variable amount of data from the hash state. Read is faster than Sum
+// because it doesn't copy the internal state, but also modifies the internal state.
+type KeccakState interface {
+	hash.Hash
+	Read([]byte) (int, error)
+}
 
 //SignatureLength indicates the byte length required to carry a signature with recovery id.
 const SignatureLength = 64 + 1 // 64 bytes ECDSA signature + 1 byte recovery id

--- a/mainchain/api.go
+++ b/mainchain/api.go
@@ -718,6 +718,9 @@ func (s *PublicKaiAPI) EstimateGas(ctx context.Context, args types.CallArgsJSON,
 		if err != nil {
 			return 0, err
 		}
+		if block == nil {
+			return 0, errors.New("block not found")
+		}
 		hi = block.GasLimit()
 	}
 	cap = hi

--- a/mainchain/api.go
+++ b/mainchain/api.go
@@ -152,8 +152,12 @@ func NewBlockJSON(block *types.Block, blockInfo *types.BlockInfo) *BlockJSON {
 	transactions := make([]*PublicTransaction, 0, len(txs))
 	basicReceipts := make([]*BasicReceipt, 0)
 
-	for _, receipt := range blockInfo.Receipts {
-		basicReceipts = append(basicReceipts, getBasicReceipt(*receipt))
+	if blockInfo != nil {
+		for _, receipt := range blockInfo.Receipts {
+			basicReceipts = append(basicReceipts, getBasicReceipt(*receipt))
+		}
+	} else {
+		blockInfo = &types.BlockInfo{}
 	}
 
 	for index, transaction := range txs {
@@ -343,7 +347,6 @@ type PublicTransaction struct {
 	Logs             []Log        `json:"logs,omitempty"`
 	LogsBloom        types.Bloom  `json:"logsBloom,omitempty"`
 	Root             common.Bytes `json:"root,omitempty"`
-	Status           uint         `json:"status"`
 }
 
 type Log struct {

--- a/mainchain/tx_pool/tx_pool.go
+++ b/mainchain/tx_pool/tx_pool.go
@@ -835,6 +835,7 @@ func (pool *TxPool) addTxs(txs []*types.Transaction, local, sync bool) []error {
 			nilSlot++
 		}
 		errs[nilSlot] = err
+		nilSlot++
 	}
 	// Reorg the pool internals if needed and return
 	done := pool.requestPromoteExecutables(dirtyAddrs)

--- a/mainchain/tx_pool/tx_pool_helper.go
+++ b/mainchain/tx_pool/tx_pool_helper.go
@@ -441,6 +441,7 @@ func (h *priceHeap) Pop() interface{} {
 	old := *h
 	n := len(old)
 	x := old[n-1]
+	old[n-1] = nil
 	*h = old[0 : n-1]
 	return x
 }

--- a/trie/hasher.go
+++ b/trie/hasher.go
@@ -17,28 +17,20 @@
 package trie
 
 import (
-	"hash"
 	"sync"
 
 	"github.com/kardiachain/go-kardia/lib/common"
+	"github.com/kardiachain/go-kardia/lib/crypto"
 	"github.com/kardiachain/go-kardia/lib/crypto/sha3"
 	"github.com/kardiachain/go-kardia/lib/rlp"
 )
 
 type hasher struct {
 	tmp        sliceBuffer
-	sha        keccakState
+	sha        crypto.KeccakState
 	cachegen   uint16
 	cachelimit uint16
 	onleaf     LeafCallback
-}
-
-// keccakState wraps sha3.state. In addition to the usual hash methods, it also supports
-// Read to get a variable amount of data from the hash state. Read is faster than Sum
-// because it doesn't copy the internal state, but also modifies the internal state.
-type keccakState interface {
-	hash.Hash
-	Read([]byte) (int, error)
 }
 
 type sliceBuffer []byte
@@ -57,7 +49,7 @@ var hasherPool = sync.Pool{
 	New: func() interface{} {
 		return &hasher{
 			tmp: make(sliceBuffer, 0, 550), // cap is as large as a full fullNode.
-			sha: sha3.NewKeccak256().(keccakState),
+			sha: sha3.NewKeccak256().(crypto.KeccakState),
 		}
 	},
 }

--- a/types/bloom9.go
+++ b/types/bloom9.go
@@ -19,10 +19,13 @@
 package types
 
 import (
+	"encoding/binary"
 	"fmt"
 	"math/big"
+	"sync"
 
 	"github.com/kardiachain/go-kardia/lib/crypto"
+	"github.com/kardiachain/go-kardia/lib/crypto/sha3"
 )
 
 type bytesBacked interface {
@@ -36,6 +39,13 @@ const (
 	// BloomBitLength represents the number of bits used in a header log bloom.
 	BloomBitLength = 8 * BloomByteLength
 )
+
+// hasherPool holds LegacyKeccak hashers.
+var hasherPool = sync.Pool{
+	New: func() interface{} {
+		return sha3.NewKeccak256().(crypto.KeccakState)
+	},
+}
 
 // Bloom represents a 2048 bit bloom filter.
 type Bloom [BloomByteLength]byte
@@ -58,70 +68,93 @@ func (b *Bloom) SetBytes(d []byte) {
 }
 
 // Add adds d to the filter. Future calls of Test(d) will return true.
-func (b *Bloom) Add(d *big.Int) {
-	bin := new(big.Int).SetBytes(b[:])
-	bin.Or(bin, bloom9(d.Bytes()))
-	b.SetBytes(bin.Bytes())
+func (b *Bloom) Add(d []byte) {
+	b.add(d, make([]byte, 6))
+}
+
+// add is internal version of Add, which takes a scratch buffer for reuse (needs to be at least 6 bytes)
+func (b *Bloom) add(d []byte, buf []byte) {
+	i1, v1, i2, v2, i3, v3 := bloomValues(d, buf)
+	b[i1] |= v1
+	b[i2] |= v2
+	b[i3] |= v3
 }
 
 // Big converts b to a big integer.
+// Note: Converting a bloom filter to a big.Int and then calling GetBytes
+// does not return the same bytes, since big.Int will trim leading zeroes
 func (b Bloom) Big() *big.Int {
 	return new(big.Int).SetBytes(b[:])
 }
 
+// Bytes returns the backing byte slice of the bloom
 func (b Bloom) Bytes() []byte {
 	return b[:]
 }
 
-func (b Bloom) Test(test *big.Int) bool {
-	return BloomLookup(b, test)
+// Test checks if the given topic is present in the bloom filter
+func (b Bloom) Test(topic []byte) bool {
+	i1, v1, i2, v2, i3, v3 := bloomValues(topic, make([]byte, 6))
+	return v1 == v1&b[i1] &&
+		v2 == v2&b[i2] &&
+		v3 == v3&b[i3]
 }
 
-func (b Bloom) TestBytes(test []byte) bool {
-	return b.Test(new(big.Int).SetBytes(test))
-
-}
-
+// CreateBloom creates a bloom filter out of the give Receipts (+Logs)
 func CreateBloom(receipts Receipts) Bloom {
-	bin := new(big.Int)
+	buf := make([]byte, 6)
+	var bin Bloom
 	for _, receipt := range receipts {
-		bin.Or(bin, LogsBloom(receipt.Logs))
-	}
-
-	return BytesToBloom(bin.Bytes())
-}
-
-func LogsBloom(logs []*Log) *big.Int {
-	bin := new(big.Int)
-	for _, log := range logs {
-		bin.Or(bin, bloom9(log.Address.Bytes()))
-		for _, b := range log.Topics {
-			bin.Or(bin, bloom9(b[:]))
+		for _, log := range receipt.Logs {
+			bin.add(log.Address.Bytes(), buf)
+			for _, b := range log.Topics {
+				bin.add(b[:], buf)
+			}
 		}
 	}
-
 	return bin
 }
 
-func bloom9(b []byte) *big.Int {
-	b = crypto.Keccak256(b[:])
-
-	r := new(big.Int)
-
-	for i := 0; i < 6; i += 2 {
-		t := big.NewInt(1)
-		b := (uint(b[i+1]) + (uint(b[i]) << 8)) & 2047
-		r.Or(r, t.Lsh(t, b))
+// LogsBloom returns the bloom bytes for the given logs
+func LogsBloom(logs []*Log) []byte {
+	buf := make([]byte, 6)
+	var bin Bloom
+	for _, log := range logs {
+		bin.add(log.Address.Bytes(), buf)
+		for _, b := range log.Topics {
+			bin.add(b[:], buf)
+		}
 	}
-
-	return r
+	return bin[:]
 }
 
-var Bloom9 = bloom9
+// Bloom9 returns the bloom filter for the given data
+func Bloom9(data []byte) []byte {
+	var b Bloom
+	b.SetBytes(data)
+	return b.Bytes()
+}
 
+// bloomValues returns the bytes (index-value pairs) to set for the given data
+func bloomValues(data []byte, hashbuf []byte) (uint, byte, uint, byte, uint, byte) {
+	sha := hasherPool.Get().(crypto.KeccakState)
+	sha.Reset()
+	sha.Write(data)
+	sha.Read(hashbuf)
+	hasherPool.Put(sha)
+	// The actual bits to flip
+	v1 := byte(1 << (hashbuf[1] & 0x7))
+	v2 := byte(1 << (hashbuf[3] & 0x7))
+	v3 := byte(1 << (hashbuf[5] & 0x7))
+	// The indices for the bytes to OR in
+	i1 := BloomByteLength - uint((binary.BigEndian.Uint16(hashbuf)&0x7ff)>>3) - 1
+	i2 := BloomByteLength - uint((binary.BigEndian.Uint16(hashbuf[2:])&0x7ff)>>3) - 1
+	i3 := BloomByteLength - uint((binary.BigEndian.Uint16(hashbuf[4:])&0x7ff)>>3) - 1
+
+	return i1, v1, i2, v2, i3, v3
+}
+
+// BloomLookup is a convenience-method to check presence int he bloom filter
 func BloomLookup(bin Bloom, topic bytesBacked) bool {
-	bloom := bin.Big()
-	cmp := bloom9(topic.Bytes()[:])
-
-	return bloom.And(bloom, cmp).Cmp(cmp) == 0
+	return bin.Test(topic.Bytes())
 }

--- a/types/bloom9_test.go
+++ b/types/bloom9_test.go
@@ -19,8 +19,12 @@
 package types
 
 import (
+	"fmt"
 	"math/big"
 	"testing"
+
+	"github.com/kardiachain/go-kardia/lib/common"
+	"github.com/kardiachain/go-kardia/lib/crypto"
 )
 
 func TestBloom(t *testing.T) {
@@ -37,17 +41,118 @@ func TestBloom(t *testing.T) {
 
 	var bloom Bloom
 	for _, data := range positive {
-		bloom.Add(new(big.Int).SetBytes([]byte(data)))
+		bloom.Add([]byte(data))
 	}
 
 	for _, data := range positive {
-		if !bloom.TestBytes([]byte(data)) {
+		if !bloom.Test([]byte(data)) {
 			t.Error("expected", data, "to test true")
 		}
 	}
 	for _, data := range negative {
-		if bloom.TestBytes([]byte(data)) {
+		if bloom.Test([]byte(data)) {
 			t.Error("did not expect", data, "to test true")
 		}
 	}
+}
+
+// TestBloomExtensively does some more thorough tests
+func TestBloomExtensively(t *testing.T) {
+	var exp = common.HexToHash("c8d3ca65cdb4874300a9e39475508f23ed6da09fdbc487f89a2dcf50b09eb263")
+	var b Bloom
+	// Add 100 "random" things
+	for i := 0; i < 100; i++ {
+		data := fmt.Sprintf("xxxxxxxxxx data %d yyyyyyyyyyyyyy", i)
+		b.Add([]byte(data))
+		//b.Add(new(big.Int).SetBytes([]byte(data)))
+	}
+	got := crypto.Keccak256Hash(b.Bytes())
+	if got != exp {
+		t.Errorf("Got %x, exp %x", got, exp)
+	}
+	var b2 Bloom
+	b2.SetBytes(b.Bytes())
+	got2 := crypto.Keccak256Hash(b2.Bytes())
+	if got != got2 {
+		t.Errorf("Got %x, exp %x", got, got2)
+	}
+}
+
+func BenchmarkBloom9(b *testing.B) {
+	test := []byte("testestestest")
+	for i := 0; i < b.N; i++ {
+		Bloom9(test)
+	}
+}
+
+func BenchmarkBloom9Lookup(b *testing.B) {
+	toTest := []byte("testtest")
+	bloom := new(Bloom)
+	for i := 0; i < b.N; i++ {
+		bloom.Test(toTest)
+	}
+}
+
+func BenchmarkCreateBloom(b *testing.B) {
+
+	var txs = Transactions{
+		NewContractCreation(1, big.NewInt(1), 1, big.NewInt(1), nil),
+		NewTransaction(2, common.HexToAddress("0x2"), big.NewInt(2), 2, big.NewInt(2), nil),
+	}
+	var rSmall = Receipts{
+		&Receipt{
+			Status:            ReceiptStatusFailed,
+			CumulativeGasUsed: 1,
+			Logs: []*Log{
+				{Address: common.BytesToAddress([]byte{0x11})},
+				{Address: common.BytesToAddress([]byte{0x01, 0x11})},
+			},
+			TxHash:          txs[0].Hash(),
+			ContractAddress: common.BytesToAddress([]byte{0x01, 0x11, 0x11}),
+			GasUsed:         1,
+		},
+		&Receipt{
+			PostState:         common.Hash{2}.Bytes(),
+			CumulativeGasUsed: 3,
+			Logs: []*Log{
+				{Address: common.BytesToAddress([]byte{0x22})},
+				{Address: common.BytesToAddress([]byte{0x02, 0x22})},
+			},
+			TxHash:          txs[1].Hash(),
+			ContractAddress: common.BytesToAddress([]byte{0x02, 0x22, 0x22}),
+			GasUsed:         2,
+		},
+	}
+
+	var rLarge = make(Receipts, 200)
+	// Fill it with 200 receipts x 2 logs
+	for i := 0; i < 200; i += 2 {
+		copy(rLarge[i:], rSmall)
+	}
+	b.Run("small", func(b *testing.B) {
+		b.ReportAllocs()
+		var bl Bloom
+		for i := 0; i < b.N; i++ {
+			bl = CreateBloom(rSmall)
+		}
+		b.StopTimer()
+		var exp = common.HexToHash("c384c56ece49458a427c67b90fefe979ebf7104795be65dc398b280f24104949")
+		got := crypto.Keccak256Hash(bl.Bytes())
+		if got != exp {
+			b.Errorf("Got %x, exp %x", got, exp)
+		}
+	})
+	b.Run("large", func(b *testing.B) {
+		b.ReportAllocs()
+		var bl Bloom
+		for i := 0; i < b.N; i++ {
+			bl = CreateBloom(rLarge)
+		}
+		b.StopTimer()
+		var exp = common.HexToHash("c384c56ece49458a427c67b90fefe979ebf7104795be65dc398b280f24104949")
+		got := crypto.Keccak256Hash(bl.Bytes())
+		if got != exp {
+			b.Errorf("Got %x, exp %x", got, exp)
+		}
+	})
 }


### PR DESCRIPTION
- [X] Fix block API and remove status field in public transaction
- [X] Fix off-by-one error when blending the new-errors into the error-slice in the txpool.
- [X] Free pointer from slice after popping element from price heap. As per the documentation for golang heap, heap Pop can cause a memory leak if the element that is returned is a pointer and is not set to nil. This causes the pointer to be held by the underlying array, such that it cannot be garbage collected.
- [X] Optimize bloom filters, fix incorrect `Add()`, `Test()`, and `TestBytes()`, make these function take `[]byte` instead of a `big.Int`. 
 
`Bloom.Add()` takes a big.Integer, then calls `d.Bytes()` to get a byte representation of the integer. It then hashes that byte representation, and uses the hash to populate the bloom filter. The problem is that if your value is an address, integer, or some other value that doesn't occupy the full 32 bytes, it gets truncated to the number of bytes that it has, and a hash of a truncated value is different than a hash of the same value with leading 0's.

So, for example, if I tried to add the value `0x000000000000000000000000000000000000000000000001a055690d9db80000` to my bloom filter using `bloom.Add(value)`, the value that got hashed would actually be `0x01a055690d9db80000`.

The `bloom.Test()` function does the same thing, as does `bloom.TestBytes()`. So if I have a Bloom filter that properly entered the topic `0x000000000000000000000000000000000000000000000001a055690d9db80000` as a 32 byte topic, and I run `bloom.TestBytes(value)` (where value is the bytes corresponding to the above topic), it will truncate the value before hashing and end up returning false.

It seems that neither of these functions are actually used by Geth. Bloom filters are created with `CreateBloom()`, which doesn't use `.Add()`, and tested with `BloomLookup()` which doesn't use `Test` or `TestBytes`. Both `CreateBloom()` and `BloomLookup()` treat 32 byte topics properly, but the corresponding BloomFilter functions do not.

- [X] Fix null pointer exception in estimate gas API