### PR TITLE
Fix block/header/event log RPC APIs

### DIFF
--- a/mainchain/api.go
+++ b/mainchain/api.go
@@ -20,7 +20,6 @@ package kai
 
 import (
 	"context"
-	"encoding/hex"
 	"errors"
 	"fmt"
 	"time"
@@ -201,8 +200,11 @@ func (s *PublicKaiAPI) GetBlockHeaderByNumber(ctx context.Context, blockNumber r
 }
 
 // GetBlockHeaderByHash returns block by block hash
-func (s *PublicKaiAPI) GetBlockHeaderByHash(ctx context.Context, blockHash string) *BlockHeaderJSON {
-	header := s.kaiService.HeaderByHash(ctx, common.HexToHash(blockHash))
+func (s *PublicKaiAPI) GetBlockHeaderByHash(ctx context.Context, blockHash rpc.BlockNumberOrHash) *BlockHeaderJSON {
+	header, _ := s.kaiService.HeaderByNumberOrHash(ctx, blockHash)
+	if header == nil {
+		return nil
+	}
 	blockInfo := s.kaiService.BlockInfoByBlockHash(ctx, header.Hash())
 	return NewBlockHeaderJSON(header, blockInfo)
 }
@@ -215,8 +217,11 @@ func (s *PublicKaiAPI) GetBlockByNumber(ctx context.Context, blockNumber rpc.Blo
 }
 
 // GetBlockByHash returns block by block hash
-func (s *PublicKaiAPI) GetBlockByHash(ctx context.Context, blockHash string) *BlockJSON {
-	block := s.kaiService.BlockByHash(ctx, common.HexToHash(blockHash))
+func (s *PublicKaiAPI) GetBlockByHash(ctx context.Context, blockHash rpc.BlockNumberOrHash) *BlockJSON {
+	block, _ := s.kaiService.BlockByNumberOrHash(ctx, blockHash)
+	if block == nil {
+		return nil
+	}
 	blockInfo := s.kaiService.BlockInfoByBlockHash(ctx, block.Hash())
 	return NewBlockJSON(block, blockInfo)
 }
@@ -508,7 +513,7 @@ func getReceiptLogs(receipt types.Receipt) []Log {
 			logs = append(logs, Log{
 				Address:     l.Address.Hex(),
 				Topics:      topics,
-				Data:        hex.EncodeToString(l.Data),
+				Data:        l.Data.String(),
 				BlockHeight: l.BlockHeight,
 				TxHash:      l.TxHash.Hex(),
 				TxIndex:     l.TxIndex,

--- a/mainchain/api_interface.go
+++ b/mainchain/api_interface.go
@@ -67,7 +67,7 @@ type APIBackend interface {
 func (k *KardiaService) HeaderByNumber(ctx context.Context, number rpc.BlockNumber) *types.Header {
 	// Return the latest block if rpc.LatestBlockNumber has been passed in
 	if number == rpc.LatestBlockNumber {
-		return k.blockchain.CurrentBlock().Header()
+		return k.blockchain.GetHeaderByHeight(k.blockchain.CurrentBlock().Header().Height - 1)
 	}
 	return k.blockchain.GetHeaderByHeight(number.Uint64())
 }
@@ -96,7 +96,7 @@ func (k *KardiaService) HeaderByNumberOrHash(ctx context.Context, blockNrOrHash 
 func (k *KardiaService) BlockByNumber(ctx context.Context, number rpc.BlockNumber) *types.Block {
 	// Return the latest block if rpc.LatestBlockNumber has been passed in
 	if number == rpc.LatestBlockNumber {
-		return k.blockchain.CurrentBlock()
+		return k.blockchain.GetBlockByHeight(k.blockchain.CurrentBlock().Height() - 1)
 	}
 	return k.blockchain.GetBlockByHeight(number.Uint64())
 }

--- a/mainchain/blockchain/block_operations.go
+++ b/mainchain/blockchain/block_operations.go
@@ -267,7 +267,7 @@ func (bo *BlockOperations) commitTransactions(txs types.Transactions, header *ty
 	// TODO(thientn): verifies the list is sorted by nonce so tx with lower nonce is execute first.
 LOOP:
 	for i, tx := range txs {
-		state.Prepare(tx.Hash(), common.Hash{}, i)
+		state.Prepare(tx.Hash(), header.Hash(), i)
 		snap := state.Snapshot()
 		// TODO(thientn): confirms nil coinbase is acceptable.
 		receipt, _, err := ApplyTransaction(bo.logger, bo.blockchain, gasPool, state, header, tx, usedGas, kvmConfig)

--- a/mainchain/filters/filter.go
+++ b/mainchain/filters/filter.go
@@ -218,7 +218,7 @@ func (f *Filter) unindexedLogs(ctx context.Context, end uint64) ([]*types.Log, e
 		}
 		blockInfo := f.backend.BlockInfoByBlockHash(ctx, header.Hash())
 		if blockInfo == nil {
-			return nil, ErrBlockInfoNotFound
+			continue
 		}
 		found, err := f.blockLogs(ctx, header, blockInfo)
 		if err != nil {


### PR DESCRIPTION
- [X] Fix empty `blockHash` when apply emitted event logs https://github.com/kardiachain/go-kardia/issues/145
- [X] Allow get block/header by hash API to get the "latest" one https://github.com/kardiachain/go-kardia/issues/146
- [X] Skip missing block info instead of returning error. Old blocks of some nodes don't have `logsBloom` within block info, I recommend to skip missing bloom blocks instead of returning error to avoid crash the logs filter query. https://github.com/kardiachain/go-kardia/issues/145