### PR TITLE
Update/event lib

### DIFF
--- a/lib/event/event.go
+++ b/lib/event/event.go
@@ -105,6 +105,7 @@ func (mux *TypeMux) Post(ev interface{}) error {
 // Stop blocks until all current deliveries have finished.
 func (mux *TypeMux) Stop() {
 	mux.mutex.Lock()
+	defer mux.mutex.Unlock()
 	for _, subs := range mux.subm {
 		for _, sub := range subs {
 			sub.closewait()
@@ -112,11 +113,11 @@ func (mux *TypeMux) Stop() {
 	}
 	mux.subm = nil
 	mux.stopped = true
-	mux.mutex.Unlock()
 }
 
 func (mux *TypeMux) del(s *TypeMuxSubscription) {
 	mux.mutex.Lock()
+	defer mux.mutex.Unlock()
 	for typ, subs := range mux.subm {
 		if pos := find(subs, s); pos >= 0 {
 			if len(subs) == 1 {
@@ -126,7 +127,6 @@ func (mux *TypeMux) del(s *TypeMuxSubscription) {
 			}
 		}
 	}
-	s.mux.mutex.Unlock()
 }
 
 func find(slice []*TypeMuxSubscription, item *TypeMuxSubscription) int {

--- a/lib/event/feed.go
+++ b/lib/event/feed.go
@@ -139,6 +139,7 @@ func (f *Feed) Send(value interface{}) (nsent int) {
 
 	if !f.typecheck(rvalue.Type()) {
 		f.sendLock <- struct{}{}
+		f.mu.Unlock()
 		panic(feedTypeError{op: "Send", got: rvalue.Type(), want: f.etype})
 	}
 	f.mu.Unlock()

--- a/lib/event/subscription.go
+++ b/lib/event/subscription.go
@@ -95,6 +95,26 @@ func (s *funcSub) Err() <-chan error {
 // Resubscribe applies backoff between calls to fn. The time between calls is adapted
 // based on the error rate, but will never exceed backoffMax.
 func Resubscribe(backoffMax time.Duration, fn ResubscribeFunc) Subscription {
+	return ResubscribeErr(backoffMax, func(ctx context.Context, _ error) (Subscription, error) {
+		return fn(ctx)
+	})
+}
+
+// A ResubscribeFunc attempts to establish a subscription.
+type ResubscribeFunc func(context.Context) (Subscription, error)
+
+// ResubscribeErr calls fn repeatedly to keep a subscription established. When the
+// subscription is established, ResubscribeErr waits for it to fail and calls fn again. This
+// process repeats until Unsubscribe is called or the active subscription ends
+// successfully.
+//
+// The difference between Resubscribe and ResubscribeErr is that with ResubscribeErr,
+// the error of the failing subscription is available to the callback for logging
+// purposes.
+//
+// ResubscribeErr applies backoff between calls to fn. The time between calls is adapted
+// based on the error rate, but will never exceed backoffMax.
+func ResubscribeErr(backoffMax time.Duration, fn ResubscribeErrFunc) Subscription {
 	s := &resubscribeSub{
 		waitTime:   backoffMax / 10,
 		backoffMax: backoffMax,
@@ -106,15 +126,18 @@ func Resubscribe(backoffMax time.Duration, fn ResubscribeFunc) Subscription {
 	return s
 }
 
-// A ResubscribeFunc attempts to establish a subscription.
-type ResubscribeFunc func(context.Context) (Subscription, error)
+// A ResubscribeErrFunc attempts to establish a subscription.
+// For every call but the first, the second argument to this function is
+// the error that occurred with the previous subscription.
+type ResubscribeErrFunc func(context.Context, error) (Subscription, error)
 
 type resubscribeSub struct {
-	fn                   ResubscribeFunc
+	fn                   ResubscribeErrFunc
 	err                  chan error
 	unsub                chan struct{}
 	unsubOnce            sync.Once
 	lastTry              sysutils.AbsTime
+	lastSubErr           error
 	waitTime, backoffMax time.Duration
 }
 
@@ -150,7 +173,7 @@ retry:
 		s.lastTry = sysutils.Now()
 		ctx, cancel := context.WithCancel(context.Background())
 		go func() {
-			rsub, err := s.fn(ctx)
+			rsub, err := s.fn(ctx, s.lastSubErr)
 			sub = rsub
 			subscribed <- err
 		}()
@@ -179,6 +202,7 @@ func (s *resubscribeSub) waitForError(sub Subscription) bool {
 	defer sub.Unsubscribe()
 	select {
 	case err := <-sub.Err():
+		s.lastSubErr = err
 		return err == nil
 	case <-s.unsub:
 		return true

--- a/lib/event/subscription.go
+++ b/lib/event/subscription.go
@@ -168,7 +168,6 @@ func (s *resubscribeSub) loop() {
 func (s *resubscribeSub) subscribe() Subscription {
 	subscribed := make(chan error)
 	var sub Subscription
-retry:
 	for {
 		s.lastTry = sysutils.Now()
 		ctx, cancel := context.WithCancel(context.Background())
@@ -180,19 +179,19 @@ retry:
 		select {
 		case err := <-subscribed:
 			cancel()
-			if err != nil {
-				// Subscribing failed, wait before launching the next try.
-				if s.backoffWait() {
-					return nil
+			if err == nil {
+				if sub == nil {
+					panic("event: ResubscribeFunc returned nil subscription and no error")
 				}
-				continue retry
+				return sub
 			}
-			if sub == nil {
-				panic("event: ResubscribeFunc returned nil subscription and no error")
+			// Subscribing failed, wait before launching the next try.
+			if s.backoffWait() {
+				return nil // unsubscribed during wait
 			}
-			return sub
 		case <-s.unsub:
 			cancel()
+			<-subscribed // avoid leaking the s.fn goroutine.
 			return nil
 		}
 	}

--- a/lib/event/subscription_test.go
+++ b/lib/event/subscription_test.go
@@ -19,6 +19,8 @@ package event
 import (
 	"context"
 	"errors"
+	"fmt"
+	"reflect"
 	"testing"
 	"time"
 )
@@ -116,5 +118,39 @@ func TestResubscribeAbort(t *testing.T) {
 	sub.Unsubscribe()
 	if err := <-done; err != nil {
 		t.Fatal(err)
+	}
+}
+
+func TestResubscribeWithErrorHandler(t *testing.T) {
+	t.Parallel()
+
+	var i int
+	nfails := 6
+	subErrs := make([]string, 0)
+	sub := ResubscribeErr(100*time.Millisecond, func(ctx context.Context, lastErr error) (Subscription, error) {
+		i++
+		var lastErrVal string
+		if lastErr != nil {
+			lastErrVal = lastErr.Error()
+		}
+		subErrs = append(subErrs, lastErrVal)
+		sub := NewSubscription(func(unsubscribed <-chan struct{}) error {
+			if i < nfails {
+				return fmt.Errorf("err-%v", i)
+			} else {
+				return nil
+			}
+		})
+		return sub, nil
+	})
+
+	<-sub.Err()
+	if i != nfails {
+		t.Fatalf("resubscribe function called %d times, want %d times", i, nfails)
+	}
+
+	expectedSubErrs := []string{"", "err-1", "err-2", "err-3", "err-4", "err-5"}
+	if !reflect.DeepEqual(subErrs, expectedSubErrs) {
+		t.Fatalf("unexpected subscription errors %v, want %v", subErrs, expectedSubErrs)
 	}
 }

--- a/lib/event/subscription_test.go
+++ b/lib/event/subscription_test.go
@@ -104,7 +104,7 @@ func TestResubscribe(t *testing.T) {
 func TestResubscribeAbort(t *testing.T) {
 	t.Parallel()
 
-	done := make(chan error)
+	done := make(chan error, 1)
 	sub := Resubscribe(0, func(ctx context.Context) (Subscription, error) {
 		select {
 		case <-ctx.Done():


### PR DESCRIPTION
- [X] Added a possibility to pass a custom callback function which will be invoked on subscription error.
This change will allow clients to receive the original subscription error and perform some additional actions like logging to make debugging easier.
- [X] Use buffered channel to avoid go-routine leak
`subscribe()` in `event/subscribe.go` has a problem: some go-routines in these functions will be leaked in certain cases (`unsub` for `subscribe()`). The `send` operation `subscribed <- err` on L177 will be blocked forever when `unsub` is selected. Thus the child go-routine leaks and always occupies the memory.
Adding one buffer to the channel will make the send operation never block the child go-routine, and it will not change semantic.
- [X] Add and organize missing and defer unlocks