### PR TITLE
Implement block and BlockInfo size

### DIFF
--- a/mainchain/api_helper.go
+++ b/mainchain/api_helper.go
@@ -64,7 +64,7 @@ func RPCMarshalHeader(head *types.Header) map[string]interface{} {
 		"miner":            head.ProposerAddress.Hex(),
 		"difficulty":       "0x000000",
 		"extraData":        common.NewZeroHash(),
-		"size":             "0x000000",
+		"size":             common.Uint64(head.Size()),
 		"gasLimit":         common.Uint64(head.GasLimit),
 		"timestamp":        common.Uint64(head.Time.Unix()),
 		"transactionsRoot": head.TxHash,
@@ -79,14 +79,15 @@ func RPCMarshalHeader(head *types.Header) map[string]interface{} {
 	}
 }
 
-// rpcMarshalBlock uses the generalized output filler, then adds adds additional fields, which requires
-// a `blockInfo`.
+// rpcMarshalBlock uses the generalized output filler, then adds additional fields, which requires
+// a types.BlockInfo.
 func (s *PublicWeb3API) rpcMarshalBlock(ctx context.Context, b *types.Block, inclTx bool, fullTx bool) (map[string]interface{}, error) {
 	fields, err := RPCMarshalBlock(b, inclTx, fullTx)
 	if err != nil {
 		return nil, err
 	}
 	fields["gasUsed"] = "0x0"
+	fields["size"] = common.Uint64(b.Size())
 	blockInfo := s.kaiService.BlockInfoByBlockHash(ctx, b.Hash())
 	if blockInfo != nil {
 		bloom, err := UnmarshalLogsBloom(&blockInfo.Bloom)
@@ -95,6 +96,7 @@ func (s *PublicWeb3API) rpcMarshalBlock(ctx context.Context, b *types.Block, inc
 		}
 		fields["gasUsed"] = common.Uint64(blockInfo.GasUsed)
 		fields["rewards"] = (*common.Big)(blockInfo.Rewards)
+		fields["size"] = common.Uint64(blockInfo.Size() + b.Size())
 	}
 	return fields, nil
 }

--- a/mainchain/filters/api_helper.go
+++ b/mainchain/filters/api_helper.go
@@ -61,6 +61,7 @@ func RPCMarshalHeader(head *types.Header) map[string]interface{} {
 		"miner":            head.ProposerAddress,
 		"difficulty":       "0x000000",
 		"extraData":        common.NewZeroHash(),
+		"size":             common.Uint64(head.Size()),
 		"gasLimit":         common.Uint64(head.GasLimit),
 		"timestamp":        common.Uint64(head.Time.Unix()),
 		"transactionsRoot": head.TxHash,

--- a/types/block.go
+++ b/types/block.go
@@ -22,14 +22,13 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"math/big"
+	"reflect"
 	"sort"
 	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
-	"unsafe"
-
-	"math/big"
 
 	"github.com/gogo/protobuf/proto"
 	"github.com/kardiachain/go-kardia/lib/common"
@@ -93,7 +92,7 @@ func (h *Header) Hash() common.Hash {
 // Size returns the approximate memory used by all internal contents. It is used
 // to approximate and limit the memory consumption of various caches.
 func (h *Header) Size() common.StorageSize {
-	return common.StorageSize(unsafe.Sizeof(*h))
+	return common.StorageSize(reflect.TypeOf(Header{}).Size())
 }
 
 // StringLong returns a long string representing full info about Header

--- a/types/receipt.go
+++ b/types/receipt.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"io"
 	"math/big"
+	"sync/atomic"
 	"unsafe"
 
 	"github.com/kardiachain/go-kardia/lib/common"
@@ -214,6 +215,8 @@ type BlockInfo struct {
 	Rewards  *big.Int // block reward
 	Receipts Receipts
 	Bloom    Bloom
+
+	size atomic.Value
 }
 
 // EncodeRLP implements rlp.Encoder, and flattens all content fields of a block info
@@ -244,6 +247,20 @@ func (bi *BlockInfo) DecodeRLP(s *rlp.Stream) error {
 		bi.Receipts[i] = (*Receipt)(receipt)
 	}
 	return nil
+}
+
+// Size returns the true RLP encoded storage size of the block info, either by
+// encoding and returning it, or returning a previously cached value.
+func (bi *BlockInfo) Size() common.StorageSize {
+	if size := bi.size.Load(); size != nil {
+		return size.(common.StorageSize)
+	}
+	c := writeCounter(0)
+	if err := rlp.Encode(&c, bi); err != nil {
+		return 0
+	}
+	bi.size.Store(common.StorageSize(c))
+	return common.StorageSize(c)
 }
 
 type storageBlockInfo struct {


### PR DESCRIPTION
- [X] Implement `size` of `Block` and `BlockInfo`, determining the true RLP encoded storage size of the block and info.
- [X] Update block and header RPC APIs to return the correct block and header size.