### PR TITLE
Fix `eth_estimateGas` params and Galaxias TxGas for testnet

### DIFF
--- a/internal/kaiapi/transaction_args.go
+++ b/internal/kaiapi/transaction_args.go
@@ -146,15 +146,17 @@ func (args *TransactionArgs) UnmarshalJSON(data []byte) error {
 	fromAddress := common.HexToAddress(fromAddressStr)
 	args.From = &fromAddress
 
-	inputStr, ok := params["input"].(string)
-	if !ok {
-		inputStr, ok = params["data"].(string)
+	if params["input"] != nil || params["data"] != nil {
+		inputStr, ok := params["input"].(string)
 		if !ok {
-			return &parseError{param: "input (data)"}
+			inputStr, ok = params["data"].(string)
+			if !ok {
+				return &parseError{param: "input (data)"}
+			}
+			inputField := (common.Bytes)(common.FromHex(inputStr))
+			args.Input = &inputField
+			args.Data = &inputField
 		}
-		inputField := (common.Bytes)(common.FromHex(inputStr))
-		args.Input = &inputField
-		args.Data = &inputField
 	}
 
 	if gas, ok := params["gas"].(float64); ok {

--- a/mainchain/api_interface.go
+++ b/mainchain/api_interface.go
@@ -82,8 +82,10 @@ type APIBackend interface {
 
 func (k *KardiaService) HeaderByHeight(ctx context.Context, height rpc.BlockHeight) *types.Header {
 	// Return the latest block if rpc.LatestBlockHeight or rpc.PendingBlockHeight has been passed in
-	if height.Uint64() >= rpc.PendingBlockHeight.Uint64() {
+	if height.Uint64() == rpc.PendingBlockHeight.Uint64() {
 		return k.blockchain.CurrentBlock().Header()
+	} else if height.Uint64() == rpc.LatestBlockHeight.Uint64() {
+		return k.blockchain.GetHeaderByHeight(k.blockchain.CurrentBlock().Header().Height - 1)
 	}
 	return k.blockchain.GetHeaderByHeight(height.Uint64())
 }

--- a/mainchain/blockchain/state_processor.go
+++ b/mainchain/blockchain/state_processor.go
@@ -92,7 +92,7 @@ func ApplyTransaction(config *configs.ChainConfig, logger log.Logger, bc vm.Chai
 	txContext := NewKVMTxContext(msg)
 	// Create a new environment which holds all relevant information
 	// about the transaction and calling mechanisms.
-	vmenv := kvm.NewKVM(context, txContext, statedb, configs.MainnetChainConfig, cfg)
+	vmenv := kvm.NewKVM(context, txContext, statedb, bc.Config(), cfg)
 	vmenv.Reset(txContext, statedb)
 	// Apply the transaction to the current state (included in the env)
 	result, err := ApplyMessage(vmenv, msg, gp)

--- a/mainchain/tracers/js/tracer.go
+++ b/mainchain/tracers/js/tracer.go
@@ -702,7 +702,9 @@ func (jst *jsTracer) CaptureStart(env *kvm.KVM, from common.Address, to common.A
 	jst.activePrecompiles = kvm.ActivePrecompiles()
 
 	// Compute intrinsic gas
-	intrinsicGas, err := tx_pool.IntrinsicGas(input, jst.ctx["type"] == "CREATE", false)
+	height := env.BlockContext.BlockHeight.Uint64()
+	isGalaxias := env.ChainConfig().IsGalaxias(&height)
+	intrinsicGas, err := tx_pool.IntrinsicGas(input, jst.ctx["type"] == "CREATE", !isGalaxias)
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
- [X] Allow the `data` and `input` fields of `eth_estimateGas` params to be `nil`
- [X] Apply post Galaxias `TxGas` (`21000` instead of `29000`) on other test networks