### PR TITLE
Simplify-iterator

### DIFF
--- a/kai/kaidb/dbtest/testsuite.go
+++ b/kai/kaidb/dbtest/testsuite.go
@@ -88,7 +88,7 @@ func TestDatabaseSuite(t *testing.T, New func() kaidb.KeyValueStore) {
 				}
 			}
 			// Iterate over the database with the given configs and verify the results
-			it, idx := db.NewIteratorWithPrefix([]byte(tt.prefix)), 0
+			it, idx := db.NewIterator([]byte(tt.prefix), nil), 0
 			for it.Next() {
 				if len(tt.order) <= idx {
 					t.Errorf("test %d: prefix=%q more items than expected: checking idx=%d (key %q), expecting len=%d", i, tt.prefix, idx, it.Key(), len(tt.order))
@@ -126,7 +126,7 @@ func TestDatabaseSuite(t *testing.T, New func() kaidb.KeyValueStore) {
 		}
 
 		{
-			it := db.NewIterator()
+			it := db.NewIterator(nil, nil)
 			got, want := iterateKeys(it), keys
 			if err := it.Error(); err != nil {
 				t.Fatal(err)
@@ -138,7 +138,7 @@ func TestDatabaseSuite(t *testing.T, New func() kaidb.KeyValueStore) {
 		}
 
 		{
-			it := db.NewIteratorWithPrefix([]byte("1"))
+			it := db.NewIterator([]byte("1"), nil)
 			got, want := iterateKeys(it), []string{"1", "10", "11", "12"}
 			if err := it.Error(); err != nil {
 				t.Fatal(err)
@@ -150,7 +150,7 @@ func TestDatabaseSuite(t *testing.T, New func() kaidb.KeyValueStore) {
 		}
 
 		{
-			it := db.NewIteratorWithPrefix([]byte("5"))
+			it := db.NewIterator([]byte("5"), nil)
 			got, want := iterateKeys(it), []string{}
 			if err := it.Error(); err != nil {
 				t.Fatal(err)
@@ -162,7 +162,7 @@ func TestDatabaseSuite(t *testing.T, New func() kaidb.KeyValueStore) {
 		}
 
 		{
-			it := db.NewIteratorWithStart([]byte("2"))
+			it := db.NewIterator(nil, []byte("2"))
 			got, want := iterateKeys(it), []string{"2", "20", "21", "22", "3", "4", "6"}
 			if err := it.Error(); err != nil {
 				t.Fatal(err)
@@ -174,7 +174,7 @@ func TestDatabaseSuite(t *testing.T, New func() kaidb.KeyValueStore) {
 		}
 
 		{
-			it := db.NewIteratorWithStart([]byte("5"))
+			it := db.NewIterator(nil, []byte("5"))
 			got, want := iterateKeys(it), []string{"6"}
 			if err := it.Error(); err != nil {
 				t.Fatal(err)
@@ -248,7 +248,7 @@ func TestDatabaseSuite(t *testing.T, New func() kaidb.KeyValueStore) {
 		}
 
 		{
-			it := db.NewIterator()
+			it := db.NewIterator(nil, nil)
 			if got, want := iterateKeys(it), []string{"1", "2", "3", "4"}; !reflect.DeepEqual(got, want) {
 				t.Errorf("got: %s; want: %s", got, want)
 			}
@@ -269,7 +269,7 @@ func TestDatabaseSuite(t *testing.T, New func() kaidb.KeyValueStore) {
 		}
 
 		{
-			it := db.NewIterator()
+			it := db.NewIterator(nil, nil)
 			if got, want := iterateKeys(it), []string{"2", "3", "4", "5", "6"}; !reflect.DeepEqual(got, want) {
 				t.Errorf("got: %s; want: %s", got, want)
 			}
@@ -298,7 +298,7 @@ func TestDatabaseSuite(t *testing.T, New func() kaidb.KeyValueStore) {
 			t.Fatal(err)
 		}
 
-		it := db.NewIterator()
+		it := db.NewIterator(nil, nil)
 		if got := iterateKeys(it); !reflect.DeepEqual(got, want) {
 			t.Errorf("got: %s; want: %s", got, want)
 		}

--- a/kai/kaidb/iterator.go
+++ b/kai/kaidb/iterator.go
@@ -53,16 +53,11 @@ type Iterator interface {
 
 // Iteratee wraps the NewIterator methods of a backing data store.
 type Iteratee interface {
-	// NewIterator creates a binary-alphabetical iterator over the entire keyspace
-	// contained within the key-value database.
-	NewIterator() Iterator
-
-	// NewIteratorWithStart creates a binary-alphabetical iterator over a subset of
-	// database content starting at a particular initial key (or after, if it does
-	// not exist).
-	NewIteratorWithStart(start []byte) Iterator
-
-	// NewIteratorWithPrefix creates a binary-alphabetical iterator over a subset
-	// of database content with a particular key prefix.
-	NewIteratorWithPrefix(prefix []byte) Iterator
+	// NewIterator creates a binary-alphabetical iterator over a subset
+	// of database content with a particular key prefix, starting at a particular
+	// initial key (or after, if it does not exist).
+	//
+	// Note: This method assumes that the prefix is NOT part of the start, so there's
+	// no need for the caller to prepend the prefix to the start
+	NewIterator(prefix []byte, start []byte) Iterator
 }

--- a/kai/kaidb/leveldb/leveldb.go
+++ b/kai/kaidb/leveldb/leveldb.go
@@ -19,29 +19,20 @@
 package leveldb
 
 import (
-	"fmt"
-	"strconv"
-	"strings"
 	"sync"
-	"time"
-
-	"github.com/kardiachain/go-kardia/kai/kaidb"
-	"github.com/kardiachain/go-kardia/lib/common"
-	"github.com/kardiachain/go-kardia/lib/log"
-	"github.com/kardiachain/go-kardia/lib/metrics"
 
 	"github.com/syndtr/goleveldb/leveldb"
 	"github.com/syndtr/goleveldb/leveldb/errors"
 	"github.com/syndtr/goleveldb/leveldb/filter"
 	"github.com/syndtr/goleveldb/leveldb/opt"
 	"github.com/syndtr/goleveldb/leveldb/util"
+
+	"github.com/kardiachain/go-kardia/kai/kaidb"
+	"github.com/kardiachain/go-kardia/lib/common"
+	"github.com/kardiachain/go-kardia/lib/log"
 )
 
 const (
-	// degradationWarnInterval specifies how often warning should be printed if the
-	// leveldb database cannot keep up with requested writes.
-	degradationWarnInterval = time.Minute
-
 	// minCache is the minimum amount of memory in megabytes to allocate to leveldb
 	// read and write caching, split half and half.
 	minCache = 16
@@ -49,10 +40,6 @@ const (
 	// minHandles is the minimum number of files handles to allocate to the open
 	// database files.
 	minHandles = 16
-
-	// metricsGatheringInterval specifies the interval to retrieve leveldb database
-	// compaction, io and pause stats to report to the user.
-	metricsGatheringInterval = 3 * time.Second
 )
 
 // Database is a persistent key-value store. Apart from basic data storage
@@ -62,19 +49,6 @@ type Database struct {
 	fn string      // filename for reporting
 	db *leveldb.DB // LevelDB instance
 
-	compTimeMeter      metrics.Meter // Meter for measuring the total time spent in database compaction
-	compReadMeter      metrics.Meter // Meter for measuring the data read during compaction
-	compWriteMeter     metrics.Meter // Meter for measuring the data written during compaction
-	writeDelayNMeter   metrics.Meter // Meter for measuring the write delay number due to database compaction
-	writeDelayMeter    metrics.Meter // Meter for measuring the write delay duration due to database compaction
-	diskSizeGauge      metrics.Gauge // Gauge for tracking the size of all the levels in the database
-	diskReadMeter      metrics.Meter // Meter for measuring the effective amount of data read
-	diskWriteMeter     metrics.Meter // Meter for measuring the effective amount of data written
-	memCompGauge       metrics.Gauge // Gauge for tracking the number of memory compaction
-	level0CompGauge    metrics.Gauge // Gauge for tracking the number of table compaction in level0
-	nonlevel0CompGauge metrics.Gauge // Gauge for tracking the number of table compaction in non0 level
-	seekCompGauge      metrics.Gauge // Gauge for tracking the number of table compaction caused by read opt
-
 	quitLock sync.Mutex      // Mutex protecting the quit channel access
 	quitChan chan chan error // Quit channel to stop the metrics collection before closing the database
 
@@ -83,7 +57,7 @@ type Database struct {
 
 // New returns a wrapped LevelDB object. The namespace is the prefix that the
 // metrics reporting should use for surfacing internal stats.
-func New(file string, cache int, handles int, namespace string) (*Database, error) {
+func New(file string, cache int, handles int) (*Database, error) {
 	// Ensure we have some minimal caching and file guarantees
 	if cache < minCache {
 		cache = minCache
@@ -100,7 +74,6 @@ func New(file string, cache int, handles int, namespace string) (*Database, erro
 		BlockCacheCapacity:     cache / 2 * opt.MiB,
 		WriteBuffer:            cache / 4 * opt.MiB, // Two of these are used internally
 		Filter:                 filter.NewBloomFilter(10),
-		DisableSeeksCompaction: true,
 	})
 	if _, corrupted := err.(*errors.ErrCorrupted); corrupted {
 		db, err = leveldb.RecoverFile(file, nil)
@@ -115,21 +88,9 @@ func New(file string, cache int, handles int, namespace string) (*Database, erro
 		log:      logger,
 		quitChan: make(chan chan error),
 	}
-	ldb.compTimeMeter = metrics.NewRegisteredMeter(namespace+"compact/time", nil)
-	ldb.compReadMeter = metrics.NewRegisteredMeter(namespace+"compact/input", nil)
-	ldb.compWriteMeter = metrics.NewRegisteredMeter(namespace+"compact/output", nil)
-	ldb.diskSizeGauge = metrics.NewRegisteredGauge(namespace+"disk/size", nil)
-	ldb.diskReadMeter = metrics.NewRegisteredMeter(namespace+"disk/read", nil)
-	ldb.diskWriteMeter = metrics.NewRegisteredMeter(namespace+"disk/write", nil)
-	ldb.writeDelayMeter = metrics.NewRegisteredMeter(namespace+"compact/writedelay/duration", nil)
-	ldb.writeDelayNMeter = metrics.NewRegisteredMeter(namespace+"compact/writedelay/counter", nil)
-	ldb.memCompGauge = metrics.NewRegisteredGauge(namespace+"compact/memory", nil)
-	ldb.level0CompGauge = metrics.NewRegisteredGauge(namespace+"compact/level0", nil)
-	ldb.nonlevel0CompGauge = metrics.NewRegisteredGauge(namespace+"compact/nonlevel0", nil)
-	ldb.seekCompGauge = metrics.NewRegisteredGauge(namespace+"compact/seek", nil)
 
 	// Start up the metrics gathering and return
-	go ldb.meter(metricsGatheringInterval)
+	go kaidb.UpdateDBMeter(kaidb.DefaultMetricGatherInterval, "leveldb", db.GetProperty, ldb.quitChan)
 	return ldb, nil
 }
 
@@ -140,9 +101,9 @@ func (db *Database) Close() error {
 	defer db.quitLock.Unlock()
 
 	if db.quitChan != nil {
-		errc := make(chan error)
-		db.quitChan <- errc
-		if err := <-errc; err != nil {
+		errCh := make(chan error)
+		db.quitChan <- errCh
+		if err := <-errCh; err != nil {
 			db.log.Error("Metrics collection failed", "err", err)
 		}
 		db.quitChan = nil
@@ -185,21 +146,8 @@ func (db *Database) NewBatch() kaidb.Batch {
 
 // NewIterator creates a binary-alphabetical iterator over the entire keyspace
 // contained within the leveldb database.
-func (db *Database) NewIterator() kaidb.Iterator {
-	return db.db.NewIterator(new(util.Range), nil)
-}
-
-// NewIteratorWithStart creates a binary-alphabetical iterator over a subset of
-// database content starting at a particular initial key (or after, if it does
-// not exist).
-func (db *Database) NewIteratorWithStart(start []byte) kaidb.Iterator {
-	return db.db.NewIterator(&util.Range{Start: start}, nil)
-}
-
-// NewIteratorWithPrefix creates a binary-alphabetical iterator over a subset
-// of database content with a particular key prefix.
-func (db *Database) NewIteratorWithPrefix(prefix []byte) kaidb.Iterator {
-	return db.db.NewIterator(util.BytesPrefix(prefix), nil)
+func (db *Database) NewIterator(prefix []byte, start []byte) kaidb.Iterator {
+	return db.db.NewIterator(bytesPrefixRange(prefix, start), nil)
 }
 
 // Stat returns a particular internal stat of the database.
@@ -221,206 +169,6 @@ func (db *Database) Compact(start []byte, limit []byte) error {
 // Path returns the path to the database directory.
 func (db *Database) Path() string {
 	return db.fn
-}
-
-// meter periodically retrieves internal leveldb counters and reports them to
-// the metrics subsystem.
-//
-// This is how a LevelDB stats table looks like (currently):
-//
-//	Compactions
-//	 Level |   Tables   |    Size(MB)   |    Time(sec)  |    Read(MB)   |   Write(MB)
-//	-------+------------+---------------+---------------+---------------+---------------
-//	   0   |          0 |       0.00000 |       1.27969 |       0.00000 |      12.31098
-//	   1   |         85 |     109.27913 |      28.09293 |     213.92493 |     214.26294
-//	   2   |        523 |    1000.37159 |       7.26059 |      66.86342 |      66.77884
-//	   3   |        570 |    1113.18458 |       0.00000 |       0.00000 |       0.00000
-//
-// This is how the write delay look like (currently):
-// DelayN:5 Delay:406.604657ms Paused: false
-//
-// This is how the iostats look like (currently):
-// Read(MB):3895.04860 Write(MB):3654.64712
-func (db *Database) meter(refresh time.Duration) {
-	// Create the counters to store current and previous compaction values
-	compactions := make([][]float64, 2)
-	for i := 0; i < 2; i++ {
-		compactions[i] = make([]float64, 4)
-	}
-	// Create storage for iostats.
-	var iostats [2]float64
-
-	// Create storage and warning log tracer for write delay.
-	var (
-		delaystats      [2]int64
-		lastWritePaused time.Time
-	)
-
-	var (
-		errc chan error
-		merr error
-	)
-
-	// Iterate ad infinitum and collect the stats
-	for i := 1; errc == nil && merr == nil; i++ {
-		// Retrieve the database stats
-		stats, err := db.db.GetProperty("leveldb.stats")
-		if err != nil {
-			db.log.Error("Failed to read database stats", "err", err)
-			merr = err
-			continue
-		}
-		// Find the compaction table, skip the header
-		lines := strings.Split(stats, "\n")
-		for len(lines) > 0 && strings.TrimSpace(lines[0]) != "Compactions" {
-			lines = lines[1:]
-		}
-		if len(lines) <= 3 {
-			db.log.Error("Compaction leveldbTable not found")
-			merr = errors.New("compaction leveldbTable not found")
-			continue
-		}
-		lines = lines[3:]
-
-		// Iterate over all the leveldbTable rows, and accumulate the entries
-		for j := 0; j < len(compactions[i%2]); j++ {
-			compactions[i%2][j] = 0
-		}
-		for _, line := range lines {
-			parts := strings.Split(line, "|")
-			if len(parts) != 6 {
-				break
-			}
-			for idx, counter := range parts[2:] {
-				value, err := strconv.ParseFloat(strings.TrimSpace(counter), 64)
-				if err != nil {
-					db.log.Error("Compaction entry parsing failed", "err", err)
-					merr = err
-					continue
-				}
-				compactions[i%2][idx] += value
-			}
-		}
-		// Update all the requested meters
-		if db.diskSizeGauge != nil {
-			db.diskSizeGauge.Update(int64(compactions[i%2][0] * 1024 * 1024))
-		}
-		if db.compTimeMeter != nil {
-			db.compTimeMeter.Mark(int64((compactions[i%2][1] - compactions[(i-1)%2][1]) * 1000 * 1000 * 1000))
-		}
-		if db.compReadMeter != nil {
-			db.compReadMeter.Mark(int64((compactions[i%2][2] - compactions[(i-1)%2][2]) * 1024 * 1024))
-		}
-		if db.compWriteMeter != nil {
-			db.compWriteMeter.Mark(int64((compactions[i%2][3] - compactions[(i-1)%2][3]) * 1024 * 1024))
-		}
-		// Retrieve the write delay statistic
-		writedelay, err := db.db.GetProperty("leveldb.writedelay")
-		if err != nil {
-			db.log.Error("Failed to read database write delay statistic", "err", err)
-			merr = err
-			continue
-		}
-		var (
-			delayN        int64
-			delayDuration string
-			duration      time.Duration
-			paused        bool
-		)
-		if n, err := fmt.Sscanf(writedelay, "DelayN:%d Delay:%s Paused:%t", &delayN, &delayDuration, &paused); n != 3 || err != nil {
-			db.log.Error("Write delay statistic not found")
-			merr = err
-			continue
-		}
-		duration, err = time.ParseDuration(delayDuration)
-		if err != nil {
-			db.log.Error("Failed to parse delay duration", "err", err)
-			merr = err
-			continue
-		}
-		if db.writeDelayNMeter != nil {
-			db.writeDelayNMeter.Mark(delayN - delaystats[0])
-		}
-		if db.writeDelayMeter != nil {
-			db.writeDelayMeter.Mark(duration.Nanoseconds() - delaystats[1])
-		}
-		// If a warning that db is performing compaction has been displayed, any subsequent
-		// warnings will be withheld for one minute not to overwhelm the user.
-		if paused && delayN-delaystats[0] == 0 && duration.Nanoseconds()-delaystats[1] == 0 &&
-			time.Now().After(lastWritePaused.Add(degradationWarnInterval)) {
-			db.log.Warn("Database compacting, degraded performance")
-			lastWritePaused = time.Now()
-		}
-		delaystats[0], delaystats[1] = delayN, duration.Nanoseconds()
-
-		// Retrieve the database iostats.
-		ioStats, err := db.db.GetProperty("leveldb.iostats")
-		if err != nil {
-			db.log.Error("Failed to read database iostats", "err", err)
-			merr = err
-			continue
-		}
-		var nRead, nWrite float64
-		parts := strings.Split(ioStats, " ")
-		if len(parts) < 2 {
-			db.log.Error("Bad syntax of ioStats", "ioStats", ioStats)
-			merr = fmt.Errorf("bad syntax of ioStats %s", ioStats)
-			continue
-		}
-		if n, err := fmt.Sscanf(parts[0], "Read(MB):%f", &nRead); n != 1 || err != nil {
-			db.log.Error("Bad syntax of read entry", "entry", parts[0])
-			merr = err
-			continue
-		}
-		if n, err := fmt.Sscanf(parts[1], "Write(MB):%f", &nWrite); n != 1 || err != nil {
-			db.log.Error("Bad syntax of write entry", "entry", parts[1])
-			merr = err
-			continue
-		}
-		if db.diskReadMeter != nil {
-			db.diskReadMeter.Mark(int64((nRead - iostats[0]) * 1024 * 1024))
-		}
-		if db.diskWriteMeter != nil {
-			db.diskWriteMeter.Mark(int64((nWrite - iostats[1]) * 1024 * 1024))
-		}
-		iostats[0], iostats[1] = nRead, nWrite
-
-		compCount, err := db.db.GetProperty("leveldb.compcount")
-		if err != nil {
-			db.log.Error("Failed to read database iostats", "err", err)
-			merr = err
-			continue
-		}
-
-		var (
-			memComp       uint32
-			level0Comp    uint32
-			nonLevel0Comp uint32
-			seekComp      uint32
-		)
-		if n, err := fmt.Sscanf(compCount, "MemComp:%d Level0Comp:%d NonLevel0Comp:%d SeekComp:%d", &memComp, &level0Comp, &nonLevel0Comp, &seekComp); n != 4 || err != nil {
-			db.log.Error("Compaction count statistic not found")
-			merr = err
-			continue
-		}
-		db.memCompGauge.Update(int64(memComp))
-		db.level0CompGauge.Update(int64(level0Comp))
-		db.nonlevel0CompGauge.Update(int64(nonLevel0Comp))
-		db.seekCompGauge.Update(int64(seekComp))
-
-		// Sleep a bit, then repeat the stats collection
-		select {
-		case errc = <-db.quitChan:
-			// Quit requesting, stop hammering the database
-		case <-time.After(refresh):
-			// Timeout, gather a new set of stats
-		}
-	}
-
-	if errc == nil {
-		errc = <-db.quitChan
-	}
-	errc <- merr
 }
 
 // batch is a write-only leveldb batch that commits changes to its host database
@@ -488,4 +236,13 @@ func (r *replayer) Delete(key []byte) {
 		return
 	}
 	r.failure = r.writer.Delete(key)
+}
+
+// bytesPrefixRange returns key range that satisfy
+// - the given prefix, and
+// - the given seek position
+func bytesPrefixRange(prefix, start []byte) *util.Range {
+	r := util.BytesPrefix(prefix)
+	r.Start = append(r.Start, start...)
+	return r
 }

--- a/kai/kaidb/memorydb/memorydb.go
+++ b/kai/kaidb/memorydb/memorydb.go
@@ -131,55 +131,26 @@ func (db *Database) NewBatch() kaidb.Batch {
 	}
 }
 
-// NewIterator creates a binary-alphabetical iterator over the entire keyspace
-// contained within the memory database.
-func (db *Database) NewIterator() kaidb.Iterator {
-	return db.NewIteratorWithStart(nil)
-}
-
-// NewIteratorWithStart creates a binary-alphabetical iterator over a subset of
-// database content starting at a particular initial key (or after, if it does
-// not exist).
-func (db *Database) NewIteratorWithStart(start []byte) kaidb.Iterator {
-	db.lock.RLock()
-	defer db.lock.RUnlock()
-
-	var (
-		st     = string(start)
-		keys   = make([]string, 0, len(db.db))
-		values = make([][]byte, 0, len(db.db))
-	)
-	// Collect the keys from the memory database corresponding to the given start
-	for key := range db.db {
-		if key >= st {
-			keys = append(keys, key)
-		}
-	}
-	// Sort the items and retrieve the associated values
-	sort.Strings(keys)
-	for _, key := range keys {
-		values = append(values, db.db[key])
-	}
-	return &iterator{
-		keys:   keys,
-		values: values,
-	}
-}
-
-// NewIteratorWithPrefix creates a binary-alphabetical iterator over a subset
-// of database content with a particular key prefix.
-func (db *Database) NewIteratorWithPrefix(prefix []byte) kaidb.Iterator {
+// NewIterator creates a binary-alphabetical iterator over a subset
+// of database content with a particular key prefix, starting at a particular
+// initial key (or after, if it does not exist).
+func (db *Database) NewIterator(prefix []byte, start []byte) kaidb.Iterator {
 	db.lock.RLock()
 	defer db.lock.RUnlock()
 
 	var (
 		pr     = string(prefix)
+		st     = string(append(prefix, start...))
 		keys   = make([]string, 0, len(db.db))
 		values = make([][]byte, 0, len(db.db))
 	)
 	// Collect the keys from the memory database corresponding to the given prefix
+	// and start
 	for key := range db.db {
-		if strings.HasPrefix(key, pr) {
+		if !strings.HasPrefix(key, pr) {
+			continue
+		}
+		if key >= st {
 			keys = append(keys, key)
 		}
 	}

--- a/kai/state/statedb.go
+++ b/kai/state/statedb.go
@@ -423,8 +423,8 @@ func (sdb *StateDB) updateStateObject(stateObject *stateObject) {
 // CreateAccount is called during the EVM CREATE operation. The situation might arise that
 // a contract does the following:
 //
-//   1. sends funds to sha(account ++ (nonce + 1))
-//   2. tx_create(sha(account ++ nonce)) (note that this gets the address of 1)
+//  1. sends funds to sha(account ++ (nonce + 1))
+//  2. tx_create(sha(account ++ nonce)) (note that this gets the address of 1)
 //
 // Carrying over the balance ensures that Ether doesn't disappear.
 func (sdb *StateDB) CreateAccount(addr common.Address) {
@@ -476,10 +476,8 @@ func (sdb *StateDB) Commit(deleteEmptyObjects bool) (root common.Hash, err error
 		delete(sdb.stateObjectsDirty, addr)
 	}
 	// Write trie changes.
-	// The onleaf func is called _serially_, so we can reuse the same account
- 	// for unmarshalling every time.
- 	var account Account
 	root, err = sdb.trie.Commit(func(leaf []byte, parent common.Hash) error {
+		var account Account
 		if err := rlp.DecodeBytes(leaf, &account); err != nil {
 			return nil
 		}

--- a/kai/state/statedb_test.go
+++ b/kai/state/statedb_test.go
@@ -49,7 +49,7 @@ func TestUpdateLeaks(t *testing.T) {
 		state.IntermediateRoot(false)
 	}
 	// Ensure that no data was leaked into the database
-	iteractor := db.NewIterator()
+	iteractor := db.NewIterator(nil, nil)
 	for iteractor.Next() {
 		t.Errorf("State leaked into database: %x -> %x", iteractor.Key(), iteractor.Value())
 	}
@@ -97,14 +97,14 @@ func TestIntermediateLeaks(t *testing.T) {
 		t.Fatalf("failed to commit final state: %v", err)
 	}
 
-	iterator := finalDb.NewIterator()
+	iterator := finalDb.NewIterator(nil, nil)
 	for iterator.Next() {
 		if _, err := transDb.Get(iterator.Key()); err != nil {
 			t.Errorf("entry missing from the transition database: %x -> %x", iterator.Key(), iterator.Value())
 		}
 	}
 
-	iterator = transDb.NewIterator()
+	iterator = transDb.NewIterator(nil, nil)
 	for iterator.Next() {
 		if _, err := finalDb.Get(iterator.Key()); err != nil {
 			t.Errorf("extra entry in the transition database: %x -> %x", iterator.Key(), iterator.Value())

--- a/kai/storage/db_info.go
+++ b/kai/storage/db_info.go
@@ -51,7 +51,7 @@ func (info *LevelDbInfo) Name() string {
 }
 
 func (info *LevelDbInfo) Start() (types.StoreDB, error) {
-	db, err := leveldb.New(info.ChainData, info.DbCaches, info.DbHandles, "")
+	db, err := leveldb.New(info.ChainData, info.DbCaches, info.DbHandles)
 	if err != nil {
 		return nil, err
 	}
@@ -66,7 +66,7 @@ func NewMemoryDatabase() types.StoreDB {
 // NewLevelDBDatabase creates a persistent key-value database without a freezer
 // moving immutable chain segments into cold storage.
 func NewLevelDBDatabase(file string, cache int, handles int, namespace string) (types.StoreDB, error) {
-	db, err := leveldb.New(file, cache, handles, namespace)
+	db, err := leveldb.New(file, cache, handles)
 	if err != nil {
 		return nil, err
 	}

--- a/lib/p2p/trust/store_test.go
+++ b/lib/p2p/trust/store_test.go
@@ -22,7 +22,7 @@ func TestTrustMetricStoreSaveLoad(t *testing.T) {
 	require.NoError(t, err)
 	defer os.Remove(dir)
 
-	historyDB, err := leveldb.New(dir, 256, 0, "")
+	historyDB, err := leveldb.New(dir, 256, 0)
 	require.NoError(t, err)
 
 	// 0 peers saved

--- a/mainchain/filters/bench_test.go
+++ b/mainchain/filters/bench_test.go
@@ -154,7 +154,7 @@ var bloomBitsPrefix = []byte("bloomBits-")
 
 func clearBloomBits(db kaidb.Database) {
 	fmt.Println("Clearing bloombits data...")
-	it := db.NewIteratorWithPrefix(bloomBitsPrefix)
+	it := db.NewIterator(bloomBitsPrefix, nil)
 	for it.Next() {
 		db.Delete(it.Key())
 	}

--- a/trie/iterator_test.go
+++ b/trie/iterator_test.go
@@ -151,7 +151,7 @@ func TestNodeIteratorCoverage(t *testing.T) {
 			}
 		}
 	}
-	it := db.diskdb.NewIterator()
+	it := db.diskdb.NewIterator(nil, nil)
 	for it.Next() {
 		key := it.Key()
 		if _, ok := hashes[common.BytesToHash(key)]; !ok {
@@ -343,7 +343,7 @@ func testIteratorContinueAfterError(t *testing.T, memonly bool) {
 	if memonly {
 		memKeys = triedb.Nodes()
 	} else {
-		it := diskdb.NewIterator()
+		it := diskdb.NewIterator(nil, nil)
 		for it.Next() {
 			diskKeys = append(diskKeys, it.Key())
 		}

--- a/trie/trie_test.go
+++ b/trie/trie_test.go
@@ -823,7 +823,7 @@ func tempDB() (string, *TrieDatabase) {
 	if err != nil {
 		panic(fmt.Sprintf("can't create temporary directory: %v", err))
 	}
-	diskdb, err := leveldb.New(dir, 256, 0, "")
+	diskdb, err := leveldb.New(dir, 256, 0)
 	if err != nil {
 		panic(fmt.Sprintf("can't create temporary database: %v", err))
 	}

--- a/types/evidence/pool.go
+++ b/types/evidence/pool.go
@@ -253,7 +253,7 @@ func (evpool *Pool) listEvidence(prefixKey []byte, maxBytes int64) ([]types.Evid
 	var evList kproto.EvidenceData // used for calculating the bytes size
 	var evSize int64
 	var totalSize int64
-	iter := evpool.evidenceDB.NewIteratorWithPrefix(prefixKey)
+	iter := evpool.evidenceDB.NewIterator(prefixKey, nil)
 	for iter.Next() {
 		var evp kproto.Evidence
 		if err := evp.Unmarshal(iter.Value()); err != nil {
@@ -280,7 +280,7 @@ func (evpool *Pool) listEvidence(prefixKey []byte, maxBytes int64) ([]types.Evid
 }
 
 func (evpool *Pool) removeExpiredPendingEvidence() (uint64, time.Time) {
-	iter := evpool.evidenceDB.NewIteratorWithPrefix([]byte(baseKeyPending))
+	iter := evpool.evidenceDB.NewIterator([]byte(baseKeyPending), nil)
 	blockEvidenceMap := make(map[string]struct{})
 	for iter.Next() {
 		ev, err := bytesToEv(iter.Value())


### PR DESCRIPTION
This PR changes the way the Iteratee interface is defined. Previously, we had:
```
NewIteratorWithPrefix(prefix []byte)
NewIteratorWithStart(start []byte)
```
But no good way to get a prefixed iterator with a given start position. As that was missing, a lot of code made one of two mistakes:
1. Use `NewIteratorWithStart( prefix ++ start)`. This solution is wrong; consider the prefix `0x0a` and start `0x00`. The returned iterator would also return e.g `0x0b`, as it is after `a` in the keyspace.
2. Use `NewIteratorWithPrefix( prefix ++ start)`. This is also wrong. Consider the prefix `0x0a` and start `0x01`. This iterator would miss a key at `0x0a02`, since `0x0a01` is not a prefix to `0x0a02`.

I replaced both of these with
```
NewIterator(prefix, start []byte)
```