### PR TITLE
Implement stacktrie to improve RLP/hashing performance

### DIFF
--- a/blockchain/msgs.go
+++ b/blockchain/msgs.go
@@ -7,6 +7,7 @@ import (
 	"github.com/gogo/protobuf/proto"
 
 	bcproto "github.com/kardiachain/go-kardia/proto/kardiachain/blockchain"
+	"github.com/kardiachain/go-kardia/trie"
 	"github.com/kardiachain/go-kardia/types"
 )
 
@@ -83,7 +84,7 @@ func ValidateMsg(pb proto.Message) error {
 			return fmt.Errorf("invalid height")
 		}
 	case *bcproto.BlockResponse:
-		_, err := types.BlockFromProto(msg.Block)
+		_, err := types.BlockFromProto(msg.Block, trie.NewStackTrie(nil))
 		if err != nil {
 			return err
 		}

--- a/blockchain/msgs_test.go
+++ b/blockchain/msgs_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/kardiachain/go-kardia/lib/common"
+	"github.com/kardiachain/go-kardia/trie"
 
 	"github.com/gogo/protobuf/proto"
 	"github.com/stretchr/testify/assert"
@@ -82,7 +83,7 @@ func TestBcStatusResponseMessageValidateBasic(t *testing.T) {
 
 // nolint:lll // ignore line length in tests
 func TestBlockchainMessageVectors(t *testing.T) {
-	block := types.NewBlock(&types.Header{Height: 3}, []*types.Transaction{TestTx}, nil, nil)
+	block := types.NewBlock(&types.Header{Height: 3}, []*types.Transaction{TestTx}, nil, nil, trie.NewStackTrie(nil))
 	//block.Version.Block = 11 // overwrite updated protocol version
 
 	bpb, err := block.ToProto()

--- a/blockchain/processor_test.go
+++ b/blockchain/processor_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/kardiachain/go-kardia/kai/state/cstate"
 	"github.com/kardiachain/go-kardia/lib/p2p"
+	"github.com/kardiachain/go-kardia/trie"
 	"github.com/kardiachain/go-kardia/types"
 )
 
@@ -28,7 +29,7 @@ type params struct {
 
 // makePcBlock makes an empty block.
 func makePcBlock(height uint64) *types.Block {
-	return types.NewBlock(&types.Header{Height: height}, nil, nil, nil)
+	return types.NewBlock(&types.Header{Height: height}, nil, nil, nil, trie.NewStackTrie(nil))
 }
 
 // makeState takes test parameters and creates a specific processor state.

--- a/blockchain/reactor.go
+++ b/blockchain/reactor.go
@@ -12,6 +12,7 @@ import (
 	"github.com/kardiachain/go-kardia/lib/p2p"
 	ksync "github.com/kardiachain/go-kardia/lib/sync"
 	bcproto "github.com/kardiachain/go-kardia/proto/kardiachain/blockchain"
+	"github.com/kardiachain/go-kardia/trie"
 	"github.com/kardiachain/go-kardia/types"
 )
 
@@ -493,7 +494,7 @@ func (r *BlockchainReactor) Receive(chID byte, src p2p.Peer, msgBytes []byte) {
 
 	case *bcproto.BlockResponse:
 		r.mtx.RLock()
-		bi, err := types.BlockFromProto(msg.Block)
+		bi, err := types.BlockFromProto(msg.Block, trie.NewStackTrie(nil))
 		if err != nil {
 			r.logger.Error("error transitioning block from protobuf", "err", err)
 			return

--- a/blockchain/reactor_test.go
+++ b/blockchain/reactor_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/kardiachain/go-kardia/mainchain/tx_pool"
 	bcproto "github.com/kardiachain/go-kardia/proto/kardiachain/blockchain"
 	kaiproto "github.com/kardiachain/go-kardia/proto/kardiachain/types"
+	"github.com/kardiachain/go-kardia/trie"
 	"github.com/kardiachain/go-kardia/types"
 	kaitime "github.com/kardiachain/go-kardia/types/time"
 )
@@ -466,14 +467,14 @@ func makeBlock(height uint64, state cstate.LatestBlockState, lastCommit *types.C
 		ValidatorsHash:     state.Validators.Hash(),
 		NextValidatorsHash: state.NextValidators.Hash(),
 		ProposerAddress:    state.Validators.Validators[0].Address,
-	}, makeTxs(height), lastCommit, nil)
+	}, makeTxs(height), lastCommit, nil, trie.NewStackTrie(nil))
 	return block
 }
 
 //func makeBlock(height uint64, state cstate.LatestBlockState, lastCommit *types.Commit) *types.Block {
 //	block := types.NewBlock(&types.Header{
 //		Height: height,
-//	}, makeTxs(height), lastCommit, nil)
+//	}, makeTxs(height), lastCommit, nil, trie.NewStackTrie(nil))
 //	return block
 //}
 

--- a/blockchain/scheduler_test.go
+++ b/blockchain/scheduler_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/kardiachain/go-kardia/configs"
 	"github.com/kardiachain/go-kardia/kai/state/cstate"
 	"github.com/kardiachain/go-kardia/lib/p2p"
+	"github.com/kardiachain/go-kardia/trie"
 	"github.com/kardiachain/go-kardia/types"
 )
 
@@ -1327,7 +1328,7 @@ func TestScSelectPeer(t *testing.T) {
 
 // makeScBlock makes an empty block.
 func makeScBlock(height uint64) *types.Block {
-	return types.NewBlock(&types.Header{Height: height}, nil, nil, nil)
+	return types.NewBlock(&types.Header{Height: height}, nil, nil, nil, trie.NewStackTrie(nil))
 }
 
 // used in place of assert.Equal(t, want, actual) to avoid failures due to

--- a/consensus/state.go
+++ b/consensus/state.go
@@ -42,6 +42,7 @@ import (
 	"github.com/kardiachain/go-kardia/lib/p2p"
 	"github.com/kardiachain/go-kardia/lib/service"
 	kproto "github.com/kardiachain/go-kardia/proto/kardiachain/types"
+	"github.com/kardiachain/go-kardia/trie"
 	"github.com/kardiachain/go-kardia/types"
 	ktime "github.com/kardiachain/go-kardia/types/time"
 )
@@ -941,7 +942,7 @@ func (cs *ConsensusState) addProposalBlockPart(msg *BlockPartMessage, peerID p2p
 		if err != nil {
 			return added, err
 		}
-		block, err := types.BlockFromProto(pbb)
+		block, err := types.BlockFromProto(pbb, trie.NewStackTrie(nil))
 		if err != nil {
 			return added, err
 		}

--- a/go.mod
+++ b/go.mod
@@ -3,12 +3,12 @@ module github.com/kardiachain/go-kardia
 go 1.14
 
 require (
-	github.com/VictoriaMetrics/fastcache v1.5.7 // indirect
+	github.com/VictoriaMetrics/fastcache v1.5.7
 	github.com/Workiva/go-datastructures v1.0.52
 	github.com/allegro/bigcache v1.2.1 // indirect
 	github.com/aristanetworks/goarista v0.0.0-20190712234253-ed1100a1c015
 	github.com/btcsuite/btcd v0.21.0-beta
-	github.com/cespare/cp v1.1.1 // indirect
+	github.com/cespare/cp v1.1.1
 	github.com/davecgh/go-spew v1.1.1
 	github.com/deckarep/golang-set v1.7.1
 	github.com/docker/docker v17.12.0-ce-rc1.0.20200531234253-77e06fda0c94+incompatible // indirect
@@ -22,7 +22,7 @@ require (
 	github.com/golang/protobuf v1.4.3
 	github.com/google/cel-go v0.3.2
 	github.com/google/go-cmp v0.5.2 // indirect
-	github.com/google/uuid v1.0.0 // indirect
+	github.com/google/uuid v1.0.0
 	github.com/gorilla/mux v1.7.3
 	github.com/gorilla/websocket v1.4.2
 	github.com/gtank/merlin v0.1.1
@@ -37,7 +37,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.8.0
 	github.com/prometheus/tsdb v0.10.0
-	github.com/rjeczalik/notify v0.9.2 // indirect
+	github.com/rjeczalik/notify v0.9.2
 	github.com/rs/cors v1.7.0
 	github.com/sasha-s/go-deadlock v0.2.0
 	github.com/shirou/gopsutil v2.20.5+incompatible

--- a/go.sum
+++ b/go.sum
@@ -485,8 +485,6 @@ golang.org/x/crypto v0.0.0-20200115085410-6d4e4cb37c7d/go.mod h1:LzIPMQfyMNhhGPh
 golang.org/x/crypto v0.0.0-20200311171314-f7b00557c8c4/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200510223506-06a226fb4e37/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
-golang.org/x/crypto v0.0.0-20201117144127-c1f2f97bffc9 h1:phUcVbl53swtrUN8kQEXFhUxPlIlWyBfKmidCu7P95o=
-golang.org/x/crypto v0.0.0-20201117144127-c1f2f97bffc9/go.mod h1:jdWPYTVW3xRLrWPugEBEK3UY2ZEsg3UU495nc5E+M+I=
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519 h1:7I4JAnoQBe7ZtJcBaYHi5UtiO8tQHbUSXxL+pnGRANg=
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
@@ -527,8 +525,6 @@ golang.org/x/net v0.0.0-20200625001655-4c5254603344/go.mod h1:/O7V0waA8r7cgGh81R
 golang.org/x/net v0.0.0-20200813134508-3edf25e44fcc/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
 golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
-golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4 h1:4nGaVu0QrbjT/AK2PRLuQfQuh6DJve+pELhqTdAj3x0=
-golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4/go.mod h1:p54w0d4576C0XHj96bSt6lcn1PtDYWL6XObtHCRCNQM=
 golang.org/x/net v0.0.0-20220722155237-a158d28d115b/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
 golang.org/x/net v0.3.0 h1:VWL6FNY2bEEmsGVKabSlHu5Irp34xmMRoqb/9lF9lxk=
 golang.org/x/net v0.3.0/go.mod h1:MBQ8lrhLObU/6UmLb4fmbmk5OcyYmqtbGd/9yIeKjEE=
@@ -542,6 +538,7 @@ golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.1.0 h1:wsuoTGHzEhffawBOhz5CYhcrV4IdKZbEyZjBMuTp12o=
 golang.org/x/sync v0.1.0/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180823144017-11551d06cbcc/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
@@ -562,7 +559,6 @@ golang.org/x/sys v0.0.0-20190726091711-fc99dfbffb4e/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190826190057-c7b8b68b1456/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190904154756-749cb33beabd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191005200804-aed5e4c7ecf9/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191120155948-bd437916bb0e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191220142924-d4481acd189f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200106162015-b016eb3dc98e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -574,21 +570,16 @@ golang.org/x/sys v0.0.0-20200814200057-3d37ad5750ed/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201015000850-e3ed0017c211/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20210330210617-4fbd30eecc44/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20210510120138-977fb7262007 h1:gG67DSER+11cZvqIMb8S8bt0vZtiN6xWYARwirrOSfE=
-golang.org/x/sys v0.0.0-20210510120138-977fb7262007/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.3.0 h1:w8ZOecv6NaNa/zC8944JTU3vz4u6Lagfk4RPQxv92NQ=
 golang.org/x/sys v0.3.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
 golang.org/x/term v0.3.0/go.mod h1:q750SLmJuPmVoN1blW3UFBPREJfb1KmY3vwxfr+nFDA=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
-golang.org/x/text v0.3.3 h1:cokOdA+Jmi5PJGXLlLllQSgYigAEfHXJAERHVMaCc2k=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=
 golang.org/x/text v0.5.0 h1:OLmvp0KP+FVG99Ct/qFiL/Fhk4zp4QQnZ7b2U+5piUM=

--- a/kai/state/cstate/validation.go
+++ b/kai/state/cstate/validation.go
@@ -21,12 +21,13 @@ package cstate
 import (
 	"fmt"
 
+	"github.com/kardiachain/go-kardia/trie"
 	"github.com/kardiachain/go-kardia/types"
 )
 
 func validateBlock(evidencePool EvidencePool, store Store, state LatestBlockState, block *types.Block) error {
 	// Validate internal consistency
-	if err := block.ValidateBasic(); err != nil {
+	if err := block.ValidateBasic(trie.NewStackTrie(nil)); err != nil {
 		return err
 	}
 

--- a/kai/storage/kvstore/accessors.go
+++ b/kai/storage/kvstore/accessors.go
@@ -32,6 +32,7 @@ import (
 	"github.com/kardiachain/go-kardia/lib/log"
 	"github.com/kardiachain/go-kardia/lib/rlp"
 	kproto "github.com/kardiachain/go-kardia/proto/kardiachain/types"
+	"github.com/kardiachain/go-kardia/trie"
 	"github.com/kardiachain/go-kardia/types"
 )
 
@@ -563,7 +564,7 @@ func ReadBlock(db kaidb.Reader, height uint64) *types.Block {
 		panic(fmt.Sprintf("Error reading block: %v", err))
 	}
 
-	block, err := types.BlockFromProto(pbb)
+	block, err := types.BlockFromProto(pbb, trie.NewStackTrie(nil))
 	if err != nil {
 		panic(fmt.Errorf("error from proto block: %w", err))
 	}

--- a/kai/storage/kvstore/accessors_test.go
+++ b/kai/storage/kvstore/accessors_test.go
@@ -23,10 +23,10 @@ import (
 	"time"
 
 	kproto "github.com/kardiachain/go-kardia/proto/kardiachain/types"
-	"github.com/kardiachain/go-kardia/trie"
 
 	"github.com/kardiachain/go-kardia/kai/kaidb/memorydb"
 	"github.com/kardiachain/go-kardia/lib/common"
+	"github.com/kardiachain/go-kardia/trie"
 	"github.com/kardiachain/go-kardia/types"
 )
 

--- a/kai/storage/kvstore/accessors_test.go
+++ b/kai/storage/kvstore/accessors_test.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	kproto "github.com/kardiachain/go-kardia/proto/kardiachain/types"
+	"github.com/kardiachain/go-kardia/trie"
 
 	"github.com/kardiachain/go-kardia/kai/kaidb/memorydb"
 	"github.com/kardiachain/go-kardia/lib/common"
@@ -71,7 +72,7 @@ func TestBlockStorage(t *testing.T) {
 		TxHash:         types.EmptyRootHash,
 		LastCommitHash: lastCommit.Hash(),
 	}
-	block := types.NewBlock(header, nil, lastCommit, nil)
+	block := types.NewBlock(header, nil, lastCommit, nil, trie.NewStackTrie(nil))
 	partsSet := block.MakePartSet(types.BlockPartSizeBytes)
 
 	// Check that no entries are in a pristine database

--- a/mainchain/blockchain/block_operations.go
+++ b/mainchain/blockchain/block_operations.go
@@ -31,6 +31,7 @@ import (
 	"github.com/kardiachain/go-kardia/mainchain/staking/misc"
 	stypes "github.com/kardiachain/go-kardia/mainchain/staking/types"
 	"github.com/kardiachain/go-kardia/mainchain/tx_pool"
+	"github.com/kardiachain/go-kardia/trie"
 	"github.com/kardiachain/go-kardia/types"
 )
 
@@ -175,9 +176,10 @@ func (bo *BlockOperations) CommitBlockTxsIfNotFound(block *types.Block, lastComm
 
 // SaveBlock saves the given block, blockParts, and seenCommit to the underlying storage.
 // seenCommit: The +2/3 precommits that were seen which committed at height.
-//             If all the nodes restart after committing a block,
-//             we need this to reload the precommits to catch-up nodes to the
-//             most recent height.  Otherwise they'd stall at H-1.
+//
+//	If all the nodes restart after committing a block,
+//	we need this to reload the precommits to catch-up nodes to the
+//	most recent height.  Otherwise they'd stall at H-1.
 func (bo *BlockOperations) SaveBlock(block *types.Block, blockParts *types.PartSet, seenCommit *types.Commit) {
 	if block == nil {
 		common.PanicSanity("BlockOperations try to save a nil block")
@@ -248,7 +250,7 @@ func (bo *BlockOperations) newHeader(time time.Time, height uint64, numTxs uint6
 
 // newBlock creates new block from given data.
 func (bo *BlockOperations) newBlock(header *types.Header, txs []*types.Transaction, commit *types.Commit, ev []types.Evidence) *types.Block {
-	block := types.NewBlock(header, txs, commit, ev)
+	block := types.NewBlock(header, txs, commit, ev, trie.NewStackTrie(nil))
 	return block
 }
 

--- a/mainchain/genesis/genesis.go
+++ b/mainchain/genesis/genesis.go
@@ -37,6 +37,7 @@ import (
 	kmath "github.com/kardiachain/go-kardia/lib/math"
 	"github.com/kardiachain/go-kardia/mainchain/staking"
 	kaiproto "github.com/kardiachain/go-kardia/proto/kardiachain/types"
+	"github.com/kardiachain/go-kardia/trie"
 	"github.com/kardiachain/go-kardia/types"
 )
 
@@ -138,10 +139,10 @@ func (e *GenesisMismatchError) Error() string {
 // SetupGenesisBlock writes or updates the genesis block in db.
 // The block that will be used is:
 //
-//                          genesis == nil       genesis != nil
-//                       +------------------------------------------
-//     db has no genesis |  main-net default  |  genesis
-//     db has genesis    |  from DB           |  genesis (if compatible)
+//	                     genesis == nil       genesis != nil
+//	                  +------------------------------------------
+//	db has no genesis |  main-net default  |  genesis
+//	db has genesis    |  from DB           |  genesis (if compatible)
 //
 // The returned chain configuration is never nil.
 func SetupGenesisBlock(logger log.Logger, db types.StoreDB, genesis *Genesis, staking *staking.StakingSmcUtil) (*configs.ChainConfig, common.Hash, error) {
@@ -247,7 +248,7 @@ func (g *Genesis) ToBlock(logger log.Logger, db kaidb.Database, staking *staking
 		head.GasLimit = configs.GenesisGasLimit
 	}
 
-	block := types.NewBlock(head, nil, &types.Commit{}, nil)
+	block := types.NewBlock(head, nil, &types.Commit{}, nil, trie.NewStackTrie(nil))
 	if err := setupGenesisStaking(staking, statedb, block.Header(), kvm.Config{}, g.Validators); err != nil {
 		panic(err)
 	}
@@ -331,7 +332,7 @@ func GenesisAllocFromData(data map[string]*big.Int) (GenesisAlloc, error) {
 	return ga, nil
 }
 
-//same as DefaultTestnetGenesisBlock, but with smart contract data
+// same as DefaultTestnetGenesisBlock, but with smart contract data
 func DefaultTestnetGenesisBlockWithContract(allocData map[string]string) *Genesis {
 	ga, err := GenesisAllocFromContractData(allocData)
 	if err != nil {

--- a/mainchain/tests/staking_smc_test.go
+++ b/mainchain/tests/staking_smc_test.go
@@ -37,6 +37,7 @@ import (
 	g "github.com/kardiachain/go-kardia/mainchain/genesis"
 	"github.com/kardiachain/go-kardia/mainchain/staking"
 	stypes "github.com/kardiachain/go-kardia/mainchain/staking/types"
+	"github.com/kardiachain/go-kardia/trie"
 	"github.com/kardiachain/go-kardia/types"
 )
 
@@ -135,7 +136,7 @@ func setup() (*blockchain.BlockChain, *state.StateDB, *staking.StakingSmcUtil, *
 			},
 		},
 	}
-	block := types.NewBlock(head, nil, &types.Commit{}, nil)
+	block := types.NewBlock(head, nil, &types.Commit{}, nil, trie.NewStackTrie(nil))
 	if err := util.SetRoot(stateDB, block.Header(), nil, kvm.Config{}); err != nil {
 		return nil, nil, nil, nil, nil, err
 	}

--- a/mainchain/tx_pool/tx_pool_test.go
+++ b/mainchain/tx_pool/tx_pool_test.go
@@ -37,6 +37,7 @@ import (
 	"github.com/kardiachain/go-kardia/lib/crypto"
 	"github.com/kardiachain/go-kardia/lib/event"
 	krand "github.com/kardiachain/go-kardia/lib/rand"
+	"github.com/kardiachain/go-kardia/trie"
 	"github.com/kardiachain/go-kardia/types"
 )
 
@@ -58,7 +59,7 @@ type testBlockChain struct {
 func (bc *testBlockChain) CurrentBlock() *types.Block {
 	return types.NewBlock(&types.Header{
 		GasLimit: bc.gasLimit,
-	}, nil, nil, nil)
+	}, nil, nil, nil, trie.NewStackTrie(nil))
 }
 
 func (bc *testBlockChain) GetBlock(hash common.Hash, number uint64) *types.Block {

--- a/trie/encoding.go
+++ b/trie/encoding.go
@@ -51,6 +51,35 @@ func hexToCompact(hex []byte) []byte {
 	return buf
 }
 
+// hexToCompactInPlace places the compact key in input buffer, returning the length
+// needed for the representation
+func hexToCompactInPlace(hex []byte) int {
+	var (
+		hexLen    = len(hex) // length of the hex input
+		firstByte = byte(0)
+	)
+	// Check if we have a terminator there
+	if hexLen > 0 && hex[hexLen-1] == 16 {
+		firstByte = 1 << 5
+		hexLen-- // last part was the terminator, ignore that
+	}
+	var (
+		binLen = hexLen/2 + 1
+		ni     = 0 // index in hex
+		bi     = 1 // index in bin (compact)
+	)
+	if hexLen&1 == 1 {
+		firstByte |= 1 << 4 // odd flag
+		firstByte |= hex[0] // first nibble is contained in the first byte
+		ni++
+	}
+	for ; ni < hexLen; bi, ni = bi+1, ni+2 {
+		hex[bi] = hex[ni]<<4 | hex[ni+1]
+	}
+	hex[0] = firstByte
+	return binLen
+}
+
 func compactToHex(compact []byte) []byte {
 	if len(compact) == 0 {
 		return compact

--- a/trie/encoding_test.go
+++ b/trie/encoding_test.go
@@ -18,6 +18,8 @@ package trie
 
 import (
 	"bytes"
+	"encoding/hex"
+	"math/rand"
 	"testing"
 )
 
@@ -71,6 +73,40 @@ func TestHexKeybytes(t *testing.T) {
 		}
 		if k := hexToKeybytes(test.hexIn); !bytes.Equal(k, test.key) {
 			t.Errorf("hexToKeybytes(%x) -> %x, want %x", test.hexIn, k, test.key)
+		}
+	}
+}
+
+func TestHexToCompactInPlace(t *testing.T) {
+	for i, keyS := range []string{
+		"00",
+		"060a040c0f000a090b040803010801010900080d090a0a0d0903000b10",
+		"10",
+	} {
+		hexBytes, _ := hex.DecodeString(keyS)
+		exp := hexToCompact(hexBytes)
+		sz := hexToCompactInPlace(hexBytes)
+		got := hexBytes[:sz]
+		if !bytes.Equal(exp, got) {
+			t.Fatalf("test %d: encoding err\ninp %v\ngot %x\nexp %x\n", i, keyS, got, exp)
+		}
+	}
+}
+
+func TestHexToCompactInPlaceRandom(t *testing.T) {
+	for i := 0; i < 10000; i++ {
+		l := rand.Intn(128)
+		key := make([]byte, l)
+		rand.Read(key)
+		hexBytes := keybytesToHex(key)
+		hexOrig := []byte(string(hexBytes))
+		exp := hexToCompact(hexBytes)
+		sz := hexToCompactInPlace(hexBytes)
+		got := hexBytes[:sz]
+
+		if !bytes.Equal(exp, got) {
+			t.Fatalf("encoding err \ncpt %x\nhex %x\ngot %x\nexp %x\n",
+				key, hexOrig, got, exp)
 		}
 	}
 }

--- a/trie/hasher.go
+++ b/trie/hasher.go
@@ -48,6 +48,7 @@ func (b *sliceBuffer) Reset() {
 type hasher struct {
 	sha      keccakState
 	tmp      sliceBuffer
+	encbuf   rlp.EncoderBuffer
 	parallel bool // Whether to use paralallel threads when hashing
 }
 
@@ -55,8 +56,9 @@ type hasher struct {
 var hasherPool = sync.Pool{
 	New: func() interface{} {
 		return &hasher{
-			tmp: make(sliceBuffer, 0, 550), // cap is as large as a full fullNode.
-			sha: sha3.NewLegacyKeccak256().(keccakState),
+			tmp:    make(sliceBuffer, 0, 550), // cap is as large as a full fullNode.
+			sha:    sha3.NewLegacyKeccak256().(keccakState),
+			encbuf: rlp.NewEncoderBuffer(nil),
 		}
 	},
 }
@@ -161,30 +163,41 @@ func (h *hasher) hashFullNodeChildren(n *fullNode) (collapsed *fullNode, cached 
 // into compact form for RLP encoding.
 // If the rlp data is smaller than 32 bytes, `nil` is returned.
 func (h *hasher) shortnodeToHash(n *shortNode, force bool) node {
-	h.tmp.Reset()
-	if err := rlp.Encode(&h.tmp, n); err != nil {
-		panic("encode error: " + err.Error())
-	}
+	n.encode(h.encbuf)
+	enc := h.encodedBytes()
 
-	if len(h.tmp) < 32 && !force {
+	if len(enc) < 32 && !force {
 		return n // Nodes smaller than 32 bytes are stored inside their parent
 	}
-	return h.hashData(h.tmp)
+	return h.hashData(enc)
 }
 
 // shortnodeToHash is used to creates a hashNode from a set of hashNodes, (which
 // may contain nil values)
 func (h *hasher) fullnodeToHash(n *fullNode, force bool) node {
-	h.tmp.Reset()
-	// Generate the RLP encoding of the node
-	if err := n.EncodeRLP(&h.tmp); err != nil {
-		panic("encode error: " + err.Error())
-	}
+	n.encode(h.encbuf)
+	enc := h.encodedBytes()
 
-	if len(h.tmp) < 32 && !force {
+	if len(enc) < 32 && !force {
 		return n // Nodes smaller than 32 bytes are stored inside their parent
 	}
-	return h.hashData(h.tmp)
+	return h.hashData(enc)
+}
+
+// encodedBytes returns the result of the last encoding operation on h.encbuf.
+// This also resets the encoder buffer.
+//
+// All node encoding must be done like this:
+//
+//	node.encode(h.encbuf)
+//	enc := h.encodedBytes()
+//
+// This convention exists because node.encode can only be inlined/escape-analyzed when
+// called on a concrete receiver type.
+func (h *hasher) encodedBytes() []byte {
+	h.tmp = h.encbuf.AppendToBytes(h.tmp[:0])
+	h.encbuf.Reset(nil)
+	return h.tmp
 }
 
 // hashData hashes the provided data

--- a/trie/iterator.go
+++ b/trie/iterator.go
@@ -22,7 +22,6 @@ import (
 	"errors"
 
 	"github.com/kardiachain/go-kardia/lib/common"
-	"github.com/kardiachain/go-kardia/lib/rlp"
 )
 
 // Iterator is a key-value trie iterator that traverses a Trie.
@@ -187,11 +186,10 @@ func (it *nodeIterator) LeafProof() [][]byte {
 			proofs := make([][]byte, 0, len(it.stack))
 
 			for i, item := range it.stack[:len(it.stack)-1] {
-			// Gather nodes that end up as hash nodes (or the root)
+				// Gather nodes that end up as hash nodes (or the root)
 				node, hashed := hasher.proofHash(item.node)
 				if _, ok := hashed.(hashNode); ok || i == 0 {
-					enc, _ := rlp.EncodeToBytes(node)
-					proofs = append(proofs, enc)
+					proofs = append(proofs, nodeToBytes(node))
 				}
 			}
 			return proofs

--- a/trie/node.go
+++ b/trie/node.go
@@ -29,6 +29,7 @@ var indices = []string{"0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "a", "b
 
 type node interface {
 	fstring(string) string
+	encode(w rlp.EncoderBuffer)
 	cache() (hashNode, bool)
 }
 

--- a/trie/node.go
+++ b/trie/node.go
@@ -114,8 +114,29 @@ func mustDecodeNode(hash, buf []byte) node {
 	return n
 }
 
-// decodeNode parses the RLP encoding of a trie node.
+// mustDecodeNodeUnsafe is a wrapper of decodeNodeUnsafe and panic if any error is
+// encountered.
+func mustDecodeNodeUnsafe(hash, buf []byte) node {
+	n, err := decodeNodeUnsafe(hash, buf)
+	if err != nil {
+		panic(fmt.Sprintf("node %x: %v", hash, err))
+	}
+	return n
+}
+
+// decodeNode parses the RLP encoding of a trie node. It will deep-copy the passed
+// byte slice for decoding, so it's safe to modify the byte slice afterwards. The-
+// decode performance of this function is not optimal, but it is suitable for most
+// scenarios with low performance requirements and hard to determine whether the
+// byte slice be modified or not.
 func decodeNode(hash, buf []byte) (node, error) {
+	return decodeNodeUnsafe(hash, common.CopyBytes(buf))
+}
+
+// decodeNodeUnsafe parses the RLP encoding of a trie node. The passed byte slice
+// will be directly referenced by node without bytes deep copy, so the input MUST
+// not be changed after.
+func decodeNodeUnsafe(hash, buf []byte) (node, error) {
 	if len(buf) == 0 {
 		return nil, io.ErrUnexpectedEOF
 	}

--- a/trie/node_enc.go
+++ b/trie/node_enc.go
@@ -1,0 +1,88 @@
+// Modifications Copyright 2023 The KardiaChain Authors
+// Copyright 2022 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package trie
+
+import (
+	"github.com/kardiachain/go-kardia/lib/rlp"
+)
+
+func nodeToBytes(n node) []byte {
+	w := rlp.NewEncoderBuffer(nil)
+	n.encode(w)
+	result := w.ToBytes()
+	w.Flush()
+	return result
+}
+
+func (n *fullNode) encode(w rlp.EncoderBuffer) {
+	offset := w.List()
+	for _, c := range n.Children {
+		if c != nil {
+			c.encode(w)
+		} else {
+			w.Write(rlp.EmptyString)
+		}
+	}
+	w.ListEnd(offset)
+}
+
+func (n *shortNode) encode(w rlp.EncoderBuffer) {
+	offset := w.List()
+	w.WriteBytes(n.Key)
+	if n.Val != nil {
+		n.Val.encode(w)
+	} else {
+		w.Write(rlp.EmptyString)
+	}
+	w.ListEnd(offset)
+}
+
+func (n hashNode) encode(w rlp.EncoderBuffer) {
+	w.WriteBytes(n)
+}
+
+func (n valueNode) encode(w rlp.EncoderBuffer) {
+	w.WriteBytes(n)
+}
+
+func (n rawFullNode) encode(w rlp.EncoderBuffer) {
+	offset := w.List()
+	for _, c := range n {
+		if c != nil {
+			c.encode(w)
+		} else {
+			w.Write(rlp.EmptyString)
+		}
+	}
+	w.ListEnd(offset)
+}
+
+func (n *rawShortNode) encode(w rlp.EncoderBuffer) {
+	offset := w.List()
+	w.WriteBytes(n.Key)
+	if n.Val != nil {
+		n.Val.encode(w)
+	} else {
+		w.Write(rlp.EmptyString)
+	}
+	w.ListEnd(offset)
+}
+
+func (n rawNode) encode(w rlp.EncoderBuffer) {
+	w.Write(n)
+}

--- a/trie/node_test.go
+++ b/trie/node_test.go
@@ -1,0 +1,193 @@
+// Modifications Copyright 2023 The KardiaChain Authors
+// Copyright 2016 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package trie
+
+import (
+	"bytes"
+	crand "crypto/rand"
+	"testing"
+
+	"github.com/kardiachain/go-kardia/lib/crypto"
+	"github.com/kardiachain/go-kardia/lib/rlp"
+)
+
+func randBytes(n int) []byte {
+	r := make([]byte, n)
+	crand.Read(r)
+	return r
+}
+
+func newTestFullNode(v []byte) []interface{} {
+	fullNodeData := []interface{}{}
+	for i := 0; i < 16; i++ {
+		k := bytes.Repeat([]byte{byte(i + 1)}, 32)
+		fullNodeData = append(fullNodeData, k)
+	}
+	fullNodeData = append(fullNodeData, v)
+	return fullNodeData
+}
+
+func TestDecodeNestedNode(t *testing.T) {
+	fullNodeData := newTestFullNode([]byte("fullnode"))
+
+	data := [][]byte{}
+	for i := 0; i < 16; i++ {
+		data = append(data, nil)
+	}
+	data = append(data, []byte("subnode"))
+	fullNodeData[15] = data
+
+	buf := bytes.NewBuffer([]byte{})
+	rlp.Encode(buf, fullNodeData)
+
+	if _, err := decodeNode([]byte("testdecode"), buf.Bytes()); err != nil {
+		t.Fatalf("decode nested full node err: %v", err)
+	}
+}
+
+func TestDecodeFullNodeWrongSizeChild(t *testing.T) {
+	fullNodeData := newTestFullNode([]byte("wrongsizechild"))
+	fullNodeData[0] = []byte("00")
+	buf := bytes.NewBuffer([]byte{})
+	rlp.Encode(buf, fullNodeData)
+
+	_, err := decodeNode([]byte("testdecode"), buf.Bytes())
+	if _, ok := err.(*decodeError); !ok {
+		t.Fatalf("decodeNode returned wrong err: %v", err)
+	}
+}
+
+func TestDecodeFullNodeWrongNestedFullNode(t *testing.T) {
+	fullNodeData := newTestFullNode([]byte("fullnode"))
+
+	data := [][]byte{}
+	for i := 0; i < 16; i++ {
+		data = append(data, []byte("123456"))
+	}
+	data = append(data, []byte("subnode"))
+	fullNodeData[15] = data
+
+	buf := bytes.NewBuffer([]byte{})
+	rlp.Encode(buf, fullNodeData)
+
+	_, err := decodeNode([]byte("testdecode"), buf.Bytes())
+	if _, ok := err.(*decodeError); !ok {
+		t.Fatalf("decodeNode returned wrong err: %v", err)
+	}
+}
+
+func TestDecodeFullNode(t *testing.T) {
+	fullNodeData := newTestFullNode([]byte("decodefullnode"))
+	buf := bytes.NewBuffer([]byte{})
+	rlp.Encode(buf, fullNodeData)
+
+	_, err := decodeNode([]byte("testdecode"), buf.Bytes())
+	if err != nil {
+		t.Fatalf("decode full node err: %v", err)
+	}
+}
+
+func BenchmarkEncodeShortNode(b *testing.B) {
+	node := &shortNode{
+		Key: []byte{0x1, 0x2},
+		Val: hashNode(randBytes(32)),
+	}
+	b.ResetTimer()
+	b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		nodeToBytes(node)
+	}
+}
+
+func BenchmarkEncodeFullNode(b *testing.B) {
+	node := &fullNode{}
+	for i := 0; i < 16; i++ {
+		node.Children[i] = hashNode(randBytes(32))
+	}
+	b.ResetTimer()
+	b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		nodeToBytes(node)
+	}
+}
+
+func BenchmarkDecodeShortNode(b *testing.B) {
+	node := &shortNode{
+		Key: []byte{0x1, 0x2},
+		Val: hashNode(randBytes(32)),
+	}
+	blob := nodeToBytes(node)
+	hash := crypto.Keccak256(blob)
+
+	b.ResetTimer()
+	b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		mustDecodeNode(hash, blob)
+	}
+}
+
+func BenchmarkDecodeShortNodeUnsafe(b *testing.B) {
+	node := &shortNode{
+		Key: []byte{0x1, 0x2},
+		Val: hashNode(randBytes(32)),
+	}
+	blob := nodeToBytes(node)
+	hash := crypto.Keccak256(blob)
+
+	b.ResetTimer()
+	b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		mustDecodeNodeUnsafe(hash, blob)
+	}
+}
+
+func BenchmarkDecodeFullNode(b *testing.B) {
+	node := &fullNode{}
+	for i := 0; i < 16; i++ {
+		node.Children[i] = hashNode(randBytes(32))
+	}
+	blob := nodeToBytes(node)
+	hash := crypto.Keccak256(blob)
+
+	b.ResetTimer()
+	b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		mustDecodeNode(hash, blob)
+	}
+}
+
+func BenchmarkDecodeFullNodeUnsafe(b *testing.B) {
+	node := &fullNode{}
+	for i := 0; i < 16; i++ {
+		node.Children[i] = hashNode(randBytes(32))
+	}
+	blob := nodeToBytes(node)
+	hash := crypto.Keccak256(blob)
+
+	b.ResetTimer()
+	b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		mustDecodeNodeUnsafe(hash, blob)
+	}
+}

--- a/trie/proof.go
+++ b/trie/proof.go
@@ -23,7 +23,6 @@ import (
 	"github.com/kardiachain/go-kardia/kai/kaidb"
 	"github.com/kardiachain/go-kardia/lib/common"
 	"github.com/kardiachain/go-kardia/lib/log"
-	"github.com/kardiachain/go-kardia/lib/rlp"
 )
 
 // Prove constructs a merkle proof for key. The result contains all encoded nodes
@@ -77,7 +76,7 @@ func (t *Trie) Prove(key []byte, fromLevel uint, proofDb kaidb.KeyValueWriter) e
 		if hash, ok := hn.(hashNode); ok || i == 0 {
 			// If the node's database encoding is a hash (or is the
 			// root node), it becomes a proof element.
-			enc, _ := rlp.EncodeToBytes(n)
+			enc := nodeToBytes(n)
 			if !ok {
 				hash = hasher.hashData(enc)
 			}

--- a/trie/stacktrie.go
+++ b/trie/stacktrie.go
@@ -22,11 +22,14 @@ import (
 	"bytes"
 	"encoding/gob"
 	"errors"
+	"fmt"
 	"io"
 	"sync"
 
+	"github.com/kardiachain/go-kardia/kai/kaidb"
 	"github.com/kardiachain/go-kardia/lib/common"
 	"github.com/kardiachain/go-kardia/lib/log"
+	"github.com/kardiachain/go-kardia/lib/rlp"
 )
 
 var ErrCommitDisabled = errors.New("no database for committing")
@@ -37,14 +40,9 @@ var stPool = sync.Pool{
 	},
 }
 
-// NodeWriteFunc is used to provide all information of a dirty node for committing
-// so that callers can flush nodes into database with desired scheme.
-type NodeWriteFunc = func(owner common.Hash, path []byte, hash common.Hash, blob []byte)
-
-func stackTrieFromPool(writeFn NodeWriteFunc, owner common.Hash) *StackTrie {
+func stackTrieFromPool(db kaidb.KeyValueWriter) *StackTrie {
 	st := stPool.Get().(*StackTrie)
-	st.owner = owner
-	st.writeFn = writeFn
+	st.db = db
 	return st
 }
 
@@ -57,41 +55,30 @@ func returnToPool(st *StackTrie) {
 // in order. Once it determines that a subtree will no longer be inserted
 // into, it will hash it and free up the memory it uses.
 type StackTrie struct {
-	owner    common.Hash    // the owner of the trie
-	nodeType uint8          // node type (as in branch, ext, leaf)
-	val      []byte         // value contained by this node if it's a leaf
-	key      []byte         // key chunk covered by this (leaf|ext) node
-	children [16]*StackTrie // list of children (for branch and exts)
-	writeFn  NodeWriteFunc  // function for committing nodes, can be nil
+	nodeType uint8                // node type (as in branch, ext, leaf)
+	val      []byte               // value contained by this node if it's a leaf
+	key      []byte               // key chunk covered by this (leaf|ext) node
+	children [16]*StackTrie       // list of children (for branch and exts)
+	db       kaidb.KeyValueWriter // Pointer to the commit db, can be nil
 }
 
 // NewStackTrie allocates and initializes an empty trie.
-func NewStackTrie(writeFn NodeWriteFunc) *StackTrie {
+func NewStackTrie(db kaidb.KeyValueWriter) *StackTrie {
 	return &StackTrie{
 		nodeType: emptyNode,
-		writeFn:  writeFn,
-	}
-}
-
-// NewStackTrieWithOwner allocates and initializes an empty trie, but with
-// the additional owner field.
-func NewStackTrieWithOwner(writeFn NodeWriteFunc, owner common.Hash) *StackTrie {
-	return &StackTrie{
-		owner:    owner,
-		nodeType: emptyNode,
-		writeFn:  writeFn,
+		db:       db,
 	}
 }
 
 // NewFromBinary initialises a serialized stacktrie with the given db.
-func NewFromBinary(data []byte, writeFn NodeWriteFunc) (*StackTrie, error) {
+func NewFromBinary(data []byte, db kaidb.KeyValueWriter) (*StackTrie, error) {
 	var st StackTrie
 	if err := st.UnmarshalBinary(data); err != nil {
 		return nil, err
 	}
 	// If a database is used, we need to recursively add it to every child
-	if writeFn != nil {
-		st.setWriter(writeFn)
+	if db != nil {
+		st.setDb(db)
 	}
 	return &st, nil
 }
@@ -103,12 +90,10 @@ func (st *StackTrie) MarshalBinary() (data []byte, err error) {
 		w = bufio.NewWriter(&b)
 	)
 	if err := gob.NewEncoder(w).Encode(struct {
-		Owner    common.Hash
-		NodeType uint8
+		Nodetype uint8
 		Val      []byte
 		Key      []byte
 	}{
-		st.owner,
 		st.nodeType,
 		st.val,
 		st.key,
@@ -139,14 +124,12 @@ func (st *StackTrie) UnmarshalBinary(data []byte) error {
 
 func (st *StackTrie) unmarshalBinary(r io.Reader) error {
 	var dec struct {
-		Owner    common.Hash
-		NodeType uint8
+		Nodetype uint8
 		Val      []byte
 		Key      []byte
 	}
 	gob.NewDecoder(r).Decode(&dec)
-	st.owner = dec.Owner
-	st.nodeType = dec.NodeType
+	st.nodeType = dec.Nodetype
 	st.val = dec.Val
 	st.key = dec.Key
 
@@ -164,25 +147,25 @@ func (st *StackTrie) unmarshalBinary(r io.Reader) error {
 	return nil
 }
 
-func (st *StackTrie) setWriter(writeFn NodeWriteFunc) {
-	st.writeFn = writeFn
+func (st *StackTrie) setDb(db kaidb.KeyValueWriter) {
+	st.db = db
 	for _, child := range st.children {
 		if child != nil {
-			child.setWriter(writeFn)
+			child.setDb(db)
 		}
 	}
 }
 
-func newLeaf(owner common.Hash, key, val []byte, writeFn NodeWriteFunc) *StackTrie {
-	st := stackTrieFromPool(writeFn, owner)
+func newLeaf(key, val []byte, db kaidb.KeyValueWriter) *StackTrie {
+	st := stackTrieFromPool(db)
 	st.nodeType = leafNode
 	st.key = append(st.key, key...)
 	st.val = val
 	return st
 }
 
-func newExt(owner common.Hash, key []byte, child *StackTrie, writeFn NodeWriteFunc) *StackTrie {
-	st := stackTrieFromPool(writeFn, owner)
+func newExt(key []byte, child *StackTrie, db kaidb.KeyValueWriter) *StackTrie {
+	st := stackTrieFromPool(db)
 	st.nodeType = extNode
 	st.key = append(st.key, key...)
 	st.children[0] = child
@@ -204,19 +187,18 @@ func (st *StackTrie) TryUpdate(key, value []byte) error {
 	if len(value) == 0 {
 		panic("deletion not supported")
 	}
-	st.insert(k[:len(k)-1], value, nil)
+	st.insert(k[:len(k)-1], value)
 	return nil
 }
 
 func (st *StackTrie) Update(key, value []byte) {
 	if err := st.TryUpdate(key, value); err != nil {
-		log.Error("Unhandled trie error in StackTrie.Update", "err", err)
+		log.Error(fmt.Sprintf("Unhandled trie error: %v", err))
 	}
 }
 
 func (st *StackTrie) Reset() {
-	st.owner = common.Hash{}
-	st.writeFn = nil
+	st.db = nil
 	st.key = st.key[:0]
 	st.val = nil
 	for i := range st.children {
@@ -239,28 +221,25 @@ func (st *StackTrie) getDiffIndex(key []byte) int {
 
 // Helper function to that inserts a (key, value) pair into
 // the trie.
-func (st *StackTrie) insert(key, value []byte, prefix []byte) {
+func (st *StackTrie) insert(key, value []byte) {
 	switch st.nodeType {
 	case branchNode: /* Branch */
 		idx := int(key[0])
-
 		// Unresolve elder siblings
 		for i := idx - 1; i >= 0; i-- {
 			if st.children[i] != nil {
 				if st.children[i].nodeType != hashedNode {
-					st.children[i].hash(append(prefix, byte(i)))
+					st.children[i].hash()
 				}
 				break
 			}
 		}
-
 		// Add new child
 		if st.children[idx] == nil {
-			st.children[idx] = newLeaf(st.owner, key[1:], value, st.writeFn)
+			st.children[idx] = newLeaf(key[1:], value, st.db)
 		} else {
-			st.children[idx].insert(key[1:], value, append(prefix, key[0]))
+			st.children[idx].insert(key[1:], value)
 		}
-
 	case extNode: /* Ext */
 		// Compare both key chunks and see where they differ
 		diffidx := st.getDiffIndex(key)
@@ -273,7 +252,7 @@ func (st *StackTrie) insert(key, value []byte, prefix []byte) {
 		if diffidx == len(st.key) {
 			// Ext key and key segment are identical, recurse into
 			// the child node.
-			st.children[0].insert(key[diffidx:], value, append(prefix, key[:diffidx]...))
+			st.children[0].insert(key[diffidx:], value)
 			return
 		}
 		// Save the original part. Depending if the break is
@@ -282,19 +261,14 @@ func (st *StackTrie) insert(key, value []byte, prefix []byte) {
 		// node directly.
 		var n *StackTrie
 		if diffidx < len(st.key)-1 {
-			// Break on the non-last byte, insert an intermediate
-			// extension. The path prefix of the newly-inserted
-			// extension should also contain the different byte.
-			n = newExt(st.owner, st.key[diffidx+1:], st.children[0], st.writeFn)
-			n.hash(append(prefix, st.key[:diffidx+1]...))
+			n = newExt(st.key[diffidx+1:], st.children[0], st.db)
 		} else {
 			// Break on the last byte, no need to insert
-			// an extension node: reuse the current node.
-			// The path prefix of the original part should
-			// still be same.
+			// an extension node: reuse the current node
 			n = st.children[0]
-			n.hash(append(prefix, st.key...))
 		}
+		// Convert to hash
+		n.hash()
 		var p *StackTrie
 		if diffidx == 0 {
 			// the break is on the first byte, so
@@ -307,12 +281,12 @@ func (st *StackTrie) insert(key, value []byte, prefix []byte) {
 			// the common prefix is at least one byte
 			// long, insert a new intermediate branch
 			// node.
-			st.children[0] = stackTrieFromPool(st.writeFn, st.owner)
+			st.children[0] = stackTrieFromPool(st.db)
 			st.children[0].nodeType = branchNode
 			p = st.children[0]
 		}
 		// Create a leaf for the inserted part
-		o := newLeaf(st.owner, key[diffidx+1:], value, st.writeFn)
+		o := newLeaf(key[diffidx+1:], value, st.db)
 
 		// Insert both child leaves where they belong:
 		origIdx := st.key[diffidx]
@@ -348,41 +322,39 @@ func (st *StackTrie) insert(key, value []byte, prefix []byte) {
 			// Convert current node into an ext,
 			// and insert a child branch node.
 			st.nodeType = extNode
-			st.children[0] = NewStackTrieWithOwner(st.writeFn, st.owner)
+			st.children[0] = NewStackTrie(st.db)
 			st.children[0].nodeType = branchNode
 			p = st.children[0]
 		}
 
-		// Create the two child leaves: one containing the original
-		// value and another containing the new value. The child leaf
-		// is hashed directly in order to free up some memory.
+		// Create the two child leaves: the one containing the
+		// original value and the one containing the new value
+		// The child leave will be hashed directly in order to
+		// free up some memory.
 		origIdx := st.key[diffidx]
-		p.children[origIdx] = newLeaf(st.owner, st.key[diffidx+1:], st.val, st.writeFn)
-		p.children[origIdx].hash(append(prefix, st.key[:diffidx+1]...))
+		p.children[origIdx] = newLeaf(st.key[diffidx+1:], st.val, st.db)
+		p.children[origIdx].hash()
 
 		newIdx := key[diffidx]
-		p.children[newIdx] = newLeaf(st.owner, key[diffidx+1:], value, st.writeFn)
+		p.children[newIdx] = newLeaf(key[diffidx+1:], value, st.db)
 
 		// Finally, cut off the key part that has been passed
 		// over to the children.
 		st.key = st.key[:diffidx]
 		st.val = nil
-
 	case emptyNode: /* Empty */
 		st.nodeType = leafNode
 		st.key = key
 		st.val = value
-
 	case hashedNode:
 		panic("trying to insert into hash")
-
 	default:
 		panic("invalid type")
 	}
 }
 
-// hash converts st into a 'hashedNode', if possible. Possible outcomes:
-//
+// hash() hashes the node 'st' and converts it into 'hashedNode', if possible.
+// Possible outcomes:
 // 1. The rlp-encoded value was >= 32 bytes:
 //   - Then the 32-byte `hash` will be accessible in `st.val`.
 //   - And the 'st.type' will be 'hashedNode'
@@ -391,138 +363,145 @@ func (st *StackTrie) insert(key, value []byte, prefix []byte) {
 //   - Then the <32 byte rlp-encoded value will be accessible in 'st.val'.
 //   - And the 'st.type' will be 'hashedNode' AGAIN
 //
-// This method also sets 'st.type' to hashedNode, and clears 'st.key'.
-func (st *StackTrie) hash(path []byte) {
-	h := newHasher(false)
-	defer returnHasherToPool(h)
-
-	st.hashRec(h, path)
-}
-
-func (st *StackTrie) hashRec(hasher *hasher, path []byte) {
-	// The switch below sets this to the RLP-encoding of this node.
-	var encodedNode []byte
+// This method will also:
+// set 'st.type' to hashedNode
+// clear 'st.key'
+func (st *StackTrie) hash() {
+	/* Shortcut if node is already hashed */
+	if st.nodeType == hashedNode {
+		return
+	}
+	// The 'hasher' is taken from a pool, but we don't actually
+	// claim an instance until all children are done with their hashing,
+	// and we actually need one
+	var h *hasher
 
 	switch st.nodeType {
-	case hashedNode:
-		return
-
-	case emptyNode:
-		st.val = emptyRoot.Bytes()
-		st.key = st.key[:0]
-		st.nodeType = hashedNode
-		return
-
 	case branchNode:
-		var nodes rawFullNode
+		var nodes [17]node
 		for i, child := range st.children {
 			if child == nil {
 				nodes[i] = nilValueNode
 				continue
 			}
-			child.hashRec(hasher, append(path, byte(i)))
+			child.hash()
 			if len(child.val) < 32 {
 				nodes[i] = rawNode(child.val)
 			} else {
 				nodes[i] = hashNode(child.val)
 			}
-
-			// Release child back to pool.
-			st.children[i] = nil
+			st.children[i] = nil // Reclaim mem from subtree
 			returnToPool(child)
 		}
-
-		nodes.encode(hasher.encbuf)
-		encodedNode = hasher.encodedBytes()
-
-	case extNode:
-		st.children[0].hashRec(hasher, append(path, st.key...))
-
-		n := rawShortNode{Key: hexToCompact(st.key)}
-		if len(st.children[0].val) < 32 {
-			n.Val = rawNode(st.children[0].val)
-		} else {
-			n.Val = hashNode(st.children[0].val)
+		nodes[16] = nilValueNode
+		h = newHasher(false)
+		defer returnHasherToPool(h)
+		h.tmp.Reset()
+		if err := rlp.Encode(&h.tmp, nodes); err != nil {
+			panic(err)
 		}
-
-		n.encode(hasher.encbuf)
-		encodedNode = hasher.encodedBytes()
-
-		// Release child back to pool.
+	case extNode:
+		st.children[0].hash()
+		h = newHasher(false)
+		defer returnHasherToPool(h)
+		h.tmp.Reset()
+		var valuenode node
+		if len(st.children[0].val) < 32 {
+			valuenode = rawNode(st.children[0].val)
+		} else {
+			valuenode = hashNode(st.children[0].val)
+		}
+		n := struct {
+			Key []byte
+			Val node
+		}{
+			Key: hexToCompact(st.key),
+			Val: valuenode,
+		}
+		if err := rlp.Encode(&h.tmp, n); err != nil {
+			panic(err)
+		}
 		returnToPool(st.children[0])
-		st.children[0] = nil
-
+		st.children[0] = nil // Reclaim mem from subtree
 	case leafNode:
+		h = newHasher(false)
+		defer returnHasherToPool(h)
+		h.tmp.Reset()
 		st.key = append(st.key, byte(16))
-		n := rawShortNode{Key: hexToCompact(st.key), Val: valueNode(st.val)}
-
-		n.encode(hasher.encbuf)
-		encodedNode = hasher.encodedBytes()
-
+		sz := hexToCompactInPlace(st.key)
+		n := [][]byte{st.key[:sz], st.val}
+		if err := rlp.Encode(&h.tmp, n); err != nil {
+			panic(err)
+		}
+	case emptyNode:
+		st.val = emptyRoot.Bytes()
+		st.key = st.key[:0]
+		st.nodeType = hashedNode
+		return
 	default:
-		panic("invalid node type")
+		panic("Invalid node type")
 	}
-
-	st.nodeType = hashedNode
 	st.key = st.key[:0]
-	if len(encodedNode) < 32 {
-		st.val = common.CopyBytes(encodedNode)
+	st.nodeType = hashedNode
+	if len(h.tmp) < 32 {
+		st.val = common.CopyBytes(h.tmp)
 		return
 	}
-
 	// Write the hash to the 'val'. We allocate a new val here to not mutate
 	// input values
-	st.val = hasher.hashData(encodedNode)
-	if st.writeFn != nil {
-		st.writeFn(st.owner, path, common.BytesToHash(st.val), encodedNode)
+	st.val = make([]byte, 32)
+	h.sha.Reset()
+	h.sha.Write(h.tmp)
+	h.sha.Read(st.val)
+	if st.db != nil {
+		// TODO! Is it safe to Put the slice here?
+		// Do all db implementations copy the value provided?
+		st.db.Put(st.val, h.tmp)
 	}
 }
 
-// Hash returns the hash of the current node.
+// Hash returns the hash of the current node
 func (st *StackTrie) Hash() (h common.Hash) {
-	hasher := newHasher(false)
-	defer returnHasherToPool(hasher)
-
-	st.hashRec(hasher, nil)
-	if len(st.val) == 32 {
-		copy(h[:], st.val)
-		return h
+	st.hash()
+	if len(st.val) != 32 {
+		// If the node's RLP isn't 32 bytes long, the node will not
+		// be hashed, and instead contain the  rlp-encoding of the
+		// node. For the top level node, we need to force the hashing.
+		ret := make([]byte, 32)
+		h := newHasher(false)
+		defer returnHasherToPool(h)
+		h.sha.Reset()
+		h.sha.Write(st.val)
+		h.sha.Read(ret)
+		return common.BytesToHash(ret)
 	}
-	// If the node's RLP isn't 32 bytes long, the node will not
-	// be hashed, and instead contain the  rlp-encoding of the
-	// node. For the top level node, we need to force the hashing.
-	hasher.sha.Reset()
-	hasher.sha.Write(st.val)
-	hasher.sha.Read(h[:])
-	return h
+	return common.BytesToHash(st.val)
 }
 
-// Commit will firstly hash the entire trie if it's still not hashed
+// Commit will firstly hash the entrie trie if it's still not hashed
 // and then commit all nodes to the associated database. Actually most
 // of the trie nodes MAY have been committed already. The main purpose
 // here is to commit the root node.
 //
 // The associated database is expected, otherwise the whole commit
 // functionality should be disabled.
-func (st *StackTrie) Commit() (h common.Hash, err error) {
-	if st.writeFn == nil {
+func (st *StackTrie) Commit() (common.Hash, error) {
+	if st.db == nil {
 		return common.Hash{}, ErrCommitDisabled
 	}
-	hasher := newHasher(false)
-	defer returnHasherToPool(hasher)
-
-	st.hashRec(hasher, nil)
-	if len(st.val) == 32 {
-		copy(h[:], st.val)
-		return h, nil
+	st.hash()
+	if len(st.val) != 32 {
+		// If the node's RLP isn't 32 bytes long, the node will not
+		// be hashed (and committed), and instead contain the  rlp-encoding of the
+		// node. For the top level node, we need to force the hashing+commit.
+		ret := make([]byte, 32)
+		h := newHasher(false)
+		defer returnHasherToPool(h)
+		h.sha.Reset()
+		h.sha.Write(st.val)
+		h.sha.Read(ret)
+		st.db.Put(ret, st.val)
+		return common.BytesToHash(ret), nil
 	}
-	// If the node's RLP isn't 32 bytes long, the node will not
-	// be hashed (and committed), and instead contain the rlp-encoding of the
-	// node. For the top level node, we need to force the hashing+commit.
-	hasher.sha.Reset()
-	hasher.sha.Write(st.val)
-	hasher.sha.Read(h[:])
-
-	st.writeFn(st.owner, nil, h, st.val)
-	return h, nil
+	return common.BytesToHash(st.val), nil
 }

--- a/trie/stacktrie.go
+++ b/trie/stacktrie.go
@@ -1,0 +1,528 @@
+// Modifications Copyright 2023 The KardiaChain Authors
+// Copyright 2020 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package trie
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/gob"
+	"errors"
+	"io"
+	"sync"
+
+	"github.com/kardiachain/go-kardia/lib/common"
+	"github.com/kardiachain/go-kardia/lib/log"
+)
+
+var ErrCommitDisabled = errors.New("no database for committing")
+
+var stPool = sync.Pool{
+	New: func() interface{} {
+		return NewStackTrie(nil)
+	},
+}
+
+// NodeWriteFunc is used to provide all information of a dirty node for committing
+// so that callers can flush nodes into database with desired scheme.
+type NodeWriteFunc = func(owner common.Hash, path []byte, hash common.Hash, blob []byte)
+
+func stackTrieFromPool(writeFn NodeWriteFunc, owner common.Hash) *StackTrie {
+	st := stPool.Get().(*StackTrie)
+	st.owner = owner
+	st.writeFn = writeFn
+	return st
+}
+
+func returnToPool(st *StackTrie) {
+	st.Reset()
+	stPool.Put(st)
+}
+
+// StackTrie is a trie implementation that expects keys to be inserted
+// in order. Once it determines that a subtree will no longer be inserted
+// into, it will hash it and free up the memory it uses.
+type StackTrie struct {
+	owner    common.Hash    // the owner of the trie
+	nodeType uint8          // node type (as in branch, ext, leaf)
+	val      []byte         // value contained by this node if it's a leaf
+	key      []byte         // key chunk covered by this (leaf|ext) node
+	children [16]*StackTrie // list of children (for branch and exts)
+	writeFn  NodeWriteFunc  // function for committing nodes, can be nil
+}
+
+// NewStackTrie allocates and initializes an empty trie.
+func NewStackTrie(writeFn NodeWriteFunc) *StackTrie {
+	return &StackTrie{
+		nodeType: emptyNode,
+		writeFn:  writeFn,
+	}
+}
+
+// NewStackTrieWithOwner allocates and initializes an empty trie, but with
+// the additional owner field.
+func NewStackTrieWithOwner(writeFn NodeWriteFunc, owner common.Hash) *StackTrie {
+	return &StackTrie{
+		owner:    owner,
+		nodeType: emptyNode,
+		writeFn:  writeFn,
+	}
+}
+
+// NewFromBinary initialises a serialized stacktrie with the given db.
+func NewFromBinary(data []byte, writeFn NodeWriteFunc) (*StackTrie, error) {
+	var st StackTrie
+	if err := st.UnmarshalBinary(data); err != nil {
+		return nil, err
+	}
+	// If a database is used, we need to recursively add it to every child
+	if writeFn != nil {
+		st.setWriter(writeFn)
+	}
+	return &st, nil
+}
+
+// MarshalBinary implements encoding.BinaryMarshaler
+func (st *StackTrie) MarshalBinary() (data []byte, err error) {
+	var (
+		b bytes.Buffer
+		w = bufio.NewWriter(&b)
+	)
+	if err := gob.NewEncoder(w).Encode(struct {
+		Owner    common.Hash
+		NodeType uint8
+		Val      []byte
+		Key      []byte
+	}{
+		st.owner,
+		st.nodeType,
+		st.val,
+		st.key,
+	}); err != nil {
+		return nil, err
+	}
+	for _, child := range st.children {
+		if child == nil {
+			w.WriteByte(0)
+			continue
+		}
+		w.WriteByte(1)
+		if childData, err := child.MarshalBinary(); err != nil {
+			return nil, err
+		} else {
+			w.Write(childData)
+		}
+	}
+	w.Flush()
+	return b.Bytes(), nil
+}
+
+// UnmarshalBinary implements encoding.BinaryUnmarshaler
+func (st *StackTrie) UnmarshalBinary(data []byte) error {
+	r := bytes.NewReader(data)
+	return st.unmarshalBinary(r)
+}
+
+func (st *StackTrie) unmarshalBinary(r io.Reader) error {
+	var dec struct {
+		Owner    common.Hash
+		NodeType uint8
+		Val      []byte
+		Key      []byte
+	}
+	gob.NewDecoder(r).Decode(&dec)
+	st.owner = dec.Owner
+	st.nodeType = dec.NodeType
+	st.val = dec.Val
+	st.key = dec.Key
+
+	var hasChild = make([]byte, 1)
+	for i := range st.children {
+		if _, err := r.Read(hasChild); err != nil {
+			return err
+		} else if hasChild[0] == 0 {
+			continue
+		}
+		var child StackTrie
+		child.unmarshalBinary(r)
+		st.children[i] = &child
+	}
+	return nil
+}
+
+func (st *StackTrie) setWriter(writeFn NodeWriteFunc) {
+	st.writeFn = writeFn
+	for _, child := range st.children {
+		if child != nil {
+			child.setWriter(writeFn)
+		}
+	}
+}
+
+func newLeaf(owner common.Hash, key, val []byte, writeFn NodeWriteFunc) *StackTrie {
+	st := stackTrieFromPool(writeFn, owner)
+	st.nodeType = leafNode
+	st.key = append(st.key, key...)
+	st.val = val
+	return st
+}
+
+func newExt(owner common.Hash, key []byte, child *StackTrie, writeFn NodeWriteFunc) *StackTrie {
+	st := stackTrieFromPool(writeFn, owner)
+	st.nodeType = extNode
+	st.key = append(st.key, key...)
+	st.children[0] = child
+	return st
+}
+
+// List all values that StackTrie#nodeType can hold
+const (
+	emptyNode = iota
+	branchNode
+	extNode
+	leafNode
+	hashedNode
+)
+
+// TryUpdate inserts a (key, value) pair into the stack trie
+func (st *StackTrie) TryUpdate(key, value []byte) error {
+	k := keybytesToHex(key)
+	if len(value) == 0 {
+		panic("deletion not supported")
+	}
+	st.insert(k[:len(k)-1], value, nil)
+	return nil
+}
+
+func (st *StackTrie) Update(key, value []byte) {
+	if err := st.TryUpdate(key, value); err != nil {
+		log.Error("Unhandled trie error in StackTrie.Update", "err", err)
+	}
+}
+
+func (st *StackTrie) Reset() {
+	st.owner = common.Hash{}
+	st.writeFn = nil
+	st.key = st.key[:0]
+	st.val = nil
+	for i := range st.children {
+		st.children[i] = nil
+	}
+	st.nodeType = emptyNode
+}
+
+// Helper function that, given a full key, determines the index
+// at which the chunk pointed by st.keyOffset is different from
+// the same chunk in the full key.
+func (st *StackTrie) getDiffIndex(key []byte) int {
+	for idx, nibble := range st.key {
+		if nibble != key[idx] {
+			return idx
+		}
+	}
+	return len(st.key)
+}
+
+// Helper function to that inserts a (key, value) pair into
+// the trie.
+func (st *StackTrie) insert(key, value []byte, prefix []byte) {
+	switch st.nodeType {
+	case branchNode: /* Branch */
+		idx := int(key[0])
+
+		// Unresolve elder siblings
+		for i := idx - 1; i >= 0; i-- {
+			if st.children[i] != nil {
+				if st.children[i].nodeType != hashedNode {
+					st.children[i].hash(append(prefix, byte(i)))
+				}
+				break
+			}
+		}
+
+		// Add new child
+		if st.children[idx] == nil {
+			st.children[idx] = newLeaf(st.owner, key[1:], value, st.writeFn)
+		} else {
+			st.children[idx].insert(key[1:], value, append(prefix, key[0]))
+		}
+
+	case extNode: /* Ext */
+		// Compare both key chunks and see where they differ
+		diffidx := st.getDiffIndex(key)
+
+		// Check if chunks are identical. If so, recurse into
+		// the child node. Otherwise, the key has to be split
+		// into 1) an optional common prefix, 2) the fullnode
+		// representing the two differing path, and 3) a leaf
+		// for each of the differentiated subtrees.
+		if diffidx == len(st.key) {
+			// Ext key and key segment are identical, recurse into
+			// the child node.
+			st.children[0].insert(key[diffidx:], value, append(prefix, key[:diffidx]...))
+			return
+		}
+		// Save the original part. Depending if the break is
+		// at the extension's last byte or not, create an
+		// intermediate extension or use the extension's child
+		// node directly.
+		var n *StackTrie
+		if diffidx < len(st.key)-1 {
+			// Break on the non-last byte, insert an intermediate
+			// extension. The path prefix of the newly-inserted
+			// extension should also contain the different byte.
+			n = newExt(st.owner, st.key[diffidx+1:], st.children[0], st.writeFn)
+			n.hash(append(prefix, st.key[:diffidx+1]...))
+		} else {
+			// Break on the last byte, no need to insert
+			// an extension node: reuse the current node.
+			// The path prefix of the original part should
+			// still be same.
+			n = st.children[0]
+			n.hash(append(prefix, st.key...))
+		}
+		var p *StackTrie
+		if diffidx == 0 {
+			// the break is on the first byte, so
+			// the current node is converted into
+			// a branch node.
+			st.children[0] = nil
+			p = st
+			st.nodeType = branchNode
+		} else {
+			// the common prefix is at least one byte
+			// long, insert a new intermediate branch
+			// node.
+			st.children[0] = stackTrieFromPool(st.writeFn, st.owner)
+			st.children[0].nodeType = branchNode
+			p = st.children[0]
+		}
+		// Create a leaf for the inserted part
+		o := newLeaf(st.owner, key[diffidx+1:], value, st.writeFn)
+
+		// Insert both child leaves where they belong:
+		origIdx := st.key[diffidx]
+		newIdx := key[diffidx]
+		p.children[origIdx] = n
+		p.children[newIdx] = o
+		st.key = st.key[:diffidx]
+
+	case leafNode: /* Leaf */
+		// Compare both key chunks and see where they differ
+		diffidx := st.getDiffIndex(key)
+
+		// Overwriting a key isn't supported, which means that
+		// the current leaf is expected to be split into 1) an
+		// optional extension for the common prefix of these 2
+		// keys, 2) a fullnode selecting the path on which the
+		// keys differ, and 3) one leaf for the differentiated
+		// component of each key.
+		if diffidx >= len(st.key) {
+			panic("Trying to insert into existing key")
+		}
+
+		// Check if the split occurs at the first nibble of the
+		// chunk. In that case, no prefix extnode is necessary.
+		// Otherwise, create that
+		var p *StackTrie
+		if diffidx == 0 {
+			// Convert current leaf into a branch
+			st.nodeType = branchNode
+			p = st
+			st.children[0] = nil
+		} else {
+			// Convert current node into an ext,
+			// and insert a child branch node.
+			st.nodeType = extNode
+			st.children[0] = NewStackTrieWithOwner(st.writeFn, st.owner)
+			st.children[0].nodeType = branchNode
+			p = st.children[0]
+		}
+
+		// Create the two child leaves: one containing the original
+		// value and another containing the new value. The child leaf
+		// is hashed directly in order to free up some memory.
+		origIdx := st.key[diffidx]
+		p.children[origIdx] = newLeaf(st.owner, st.key[diffidx+1:], st.val, st.writeFn)
+		p.children[origIdx].hash(append(prefix, st.key[:diffidx+1]...))
+
+		newIdx := key[diffidx]
+		p.children[newIdx] = newLeaf(st.owner, key[diffidx+1:], value, st.writeFn)
+
+		// Finally, cut off the key part that has been passed
+		// over to the children.
+		st.key = st.key[:diffidx]
+		st.val = nil
+
+	case emptyNode: /* Empty */
+		st.nodeType = leafNode
+		st.key = key
+		st.val = value
+
+	case hashedNode:
+		panic("trying to insert into hash")
+
+	default:
+		panic("invalid type")
+	}
+}
+
+// hash converts st into a 'hashedNode', if possible. Possible outcomes:
+//
+// 1. The rlp-encoded value was >= 32 bytes:
+//   - Then the 32-byte `hash` will be accessible in `st.val`.
+//   - And the 'st.type' will be 'hashedNode'
+//
+// 2. The rlp-encoded value was < 32 bytes
+//   - Then the <32 byte rlp-encoded value will be accessible in 'st.val'.
+//   - And the 'st.type' will be 'hashedNode' AGAIN
+//
+// This method also sets 'st.type' to hashedNode, and clears 'st.key'.
+func (st *StackTrie) hash(path []byte) {
+	h := newHasher(false)
+	defer returnHasherToPool(h)
+
+	st.hashRec(h, path)
+}
+
+func (st *StackTrie) hashRec(hasher *hasher, path []byte) {
+	// The switch below sets this to the RLP-encoding of this node.
+	var encodedNode []byte
+
+	switch st.nodeType {
+	case hashedNode:
+		return
+
+	case emptyNode:
+		st.val = emptyRoot.Bytes()
+		st.key = st.key[:0]
+		st.nodeType = hashedNode
+		return
+
+	case branchNode:
+		var nodes rawFullNode
+		for i, child := range st.children {
+			if child == nil {
+				nodes[i] = nilValueNode
+				continue
+			}
+			child.hashRec(hasher, append(path, byte(i)))
+			if len(child.val) < 32 {
+				nodes[i] = rawNode(child.val)
+			} else {
+				nodes[i] = hashNode(child.val)
+			}
+
+			// Release child back to pool.
+			st.children[i] = nil
+			returnToPool(child)
+		}
+
+		nodes.encode(hasher.encbuf)
+		encodedNode = hasher.encodedBytes()
+
+	case extNode:
+		st.children[0].hashRec(hasher, append(path, st.key...))
+
+		n := rawShortNode{Key: hexToCompact(st.key)}
+		if len(st.children[0].val) < 32 {
+			n.Val = rawNode(st.children[0].val)
+		} else {
+			n.Val = hashNode(st.children[0].val)
+		}
+
+		n.encode(hasher.encbuf)
+		encodedNode = hasher.encodedBytes()
+
+		// Release child back to pool.
+		returnToPool(st.children[0])
+		st.children[0] = nil
+
+	case leafNode:
+		st.key = append(st.key, byte(16))
+		n := rawShortNode{Key: hexToCompact(st.key), Val: valueNode(st.val)}
+
+		n.encode(hasher.encbuf)
+		encodedNode = hasher.encodedBytes()
+
+	default:
+		panic("invalid node type")
+	}
+
+	st.nodeType = hashedNode
+	st.key = st.key[:0]
+	if len(encodedNode) < 32 {
+		st.val = common.CopyBytes(encodedNode)
+		return
+	}
+
+	// Write the hash to the 'val'. We allocate a new val here to not mutate
+	// input values
+	st.val = hasher.hashData(encodedNode)
+	if st.writeFn != nil {
+		st.writeFn(st.owner, path, common.BytesToHash(st.val), encodedNode)
+	}
+}
+
+// Hash returns the hash of the current node.
+func (st *StackTrie) Hash() (h common.Hash) {
+	hasher := newHasher(false)
+	defer returnHasherToPool(hasher)
+
+	st.hashRec(hasher, nil)
+	if len(st.val) == 32 {
+		copy(h[:], st.val)
+		return h
+	}
+	// If the node's RLP isn't 32 bytes long, the node will not
+	// be hashed, and instead contain the  rlp-encoding of the
+	// node. For the top level node, we need to force the hashing.
+	hasher.sha.Reset()
+	hasher.sha.Write(st.val)
+	hasher.sha.Read(h[:])
+	return h
+}
+
+// Commit will firstly hash the entire trie if it's still not hashed
+// and then commit all nodes to the associated database. Actually most
+// of the trie nodes MAY have been committed already. The main purpose
+// here is to commit the root node.
+//
+// The associated database is expected, otherwise the whole commit
+// functionality should be disabled.
+func (st *StackTrie) Commit() (h common.Hash, err error) {
+	if st.writeFn == nil {
+		return common.Hash{}, ErrCommitDisabled
+	}
+	hasher := newHasher(false)
+	defer returnHasherToPool(hasher)
+
+	st.hashRec(hasher, nil)
+	if len(st.val) == 32 {
+		copy(h[:], st.val)
+		return h, nil
+	}
+	// If the node's RLP isn't 32 bytes long, the node will not
+	// be hashed (and committed), and instead contain the rlp-encoding of the
+	// node. For the top level node, we need to force the hashing+commit.
+	hasher.sha.Reset()
+	hasher.sha.Write(st.val)
+	hasher.sha.Read(h[:])
+
+	st.writeFn(st.owner, nil, h, st.val)
+	return h, nil
+}

--- a/trie/stacktrie_test.go
+++ b/trie/stacktrie_test.go
@@ -1,0 +1,395 @@
+// Modifications Copyright 2023 The KardiaChain Authors
+// Copyright 2020 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package trie
+
+import (
+	"bytes"
+	"math/big"
+	"testing"
+
+	"github.com/kardiachain/go-kardia/kai/storage"
+	"github.com/kardiachain/go-kardia/lib/common"
+	"github.com/kardiachain/go-kardia/lib/crypto"
+)
+
+func TestStackTrieInsertAndHash(t *testing.T) {
+	type KeyValueHash struct {
+		K string // Hex string for key.
+		V string // Value, directly converted to bytes.
+		H string // Expected root hash after insert of (K, V) to an existing trie.
+	}
+	tests := [][]KeyValueHash{
+		{ // {0:0, 7:0, f:0}
+			{"00", "v_______________________0___0", "5cb26357b95bb9af08475be00243ceb68ade0b66b5cd816b0c18a18c612d2d21"},
+			{"70", "v_______________________0___1", "8ff64309574f7a437a7ad1628e690eb7663cfde10676f8a904a8c8291dbc1603"},
+			{"f0", "v_______________________0___2", "9e3a01bd8d43efb8e9d4b5506648150b8e3ed1caea596f84ee28e01a72635470"},
+		},
+		{ // {1:0cc, e:{1:fc, e:fc}}
+			{"10cc", "v_______________________1___0", "233e9b257843f3dfdb1cce6676cdaf9e595ac96ee1b55031434d852bc7ac9185"},
+			{"e1fc", "v_______________________1___1", "39c5e908ae83d0c78520c7c7bda0b3782daf594700e44546e93def8f049cca95"},
+			{"eefc", "v_______________________1___2", "d789567559fd76fe5b7d9cc42f3750f942502ac1c7f2a466e2f690ec4b6c2a7c"},
+		},
+		{ // {b:{a:ac, b:ac}, d:acc}
+			{"baac", "v_______________________2___0", "8be1c86ba7ec4c61e14c1a9b75055e0464c2633ae66a055a24e75450156a5d42"},
+			{"bbac", "v_______________________2___1", "8495159b9895a7d88d973171d737c0aace6fe6ac02a4769fff1bc43bcccce4cc"},
+			{"dacc", "v_______________________2___2", "9bcfc5b220a27328deb9dc6ee2e3d46c9ebc9c69e78acda1fa2c7040602c63ca"},
+		},
+		{ // {0:0cccc, 2:456{0:0, 2:2}
+			{"00cccc", "v_______________________3___0", "e57dc2785b99ce9205080cb41b32ebea7ac3e158952b44c87d186e6d190a6530"},
+			{"245600", "v_______________________3___1", "0335354adbd360a45c1871a842452287721b64b4234dfe08760b243523c998db"},
+			{"245622", "v_______________________3___2", "9e6832db0dca2b5cf81c0e0727bfde6afc39d5de33e5720bccacc183c162104e"},
+		},
+		{ // {1:4567{1:1c, 3:3c}, 3:0cccccc}
+			{"1456711c", "v_______________________4___0", "f2389e78d98fed99f3e63d6d1623c1d4d9e8c91cb1d585de81fbc7c0e60d3529"},
+			{"1456733c", "v_______________________4___1", "101189b3fab852be97a0120c03d95eefcf984d3ed639f2328527de6def55a9c0"},
+			{"30cccccc", "v_______________________4___2", "3780ce111f98d15751dfde1eb21080efc7d3914b429e5c84c64db637c55405b3"},
+		},
+		{ // 8800{1:f, 2:e, 3:d}
+			{"88001f", "v_______________________5___0", "e817db50d84f341d443c6f6593cafda093fc85e773a762421d47daa6ac993bd5"},
+			{"88002e", "v_______________________5___1", "d6e3e6047bdc110edd296a4d63c030aec451bee9d8075bc5a198eee8cda34f68"},
+			{"88003d", "v_______________________5___2", "b6bdf8298c703342188e5f7f84921a402042d0e5fb059969dd53a6b6b1fb989e"},
+		},
+		{ // 0{1:fc, 2:ec, 4:dc}
+			{"01fc", "v_______________________6___0", "693268f2ca80d32b015f61cd2c4dba5a47a6b52a14c34f8e6945fad684e7a0d5"},
+			{"02ec", "v_______________________6___1", "e24ddd44469310c2b785a2044618874bf486d2f7822603a9b8dce58d6524d5de"},
+			{"04dc", "v_______________________6___2", "33fc259629187bbe54b92f82f0cd8083b91a12e41a9456b84fc155321e334db7"},
+		},
+		{ // f{0:fccc, f:ff{0:f, f:f}}
+			{"f0fccc", "v_______________________7___0", "b0966b5aa469a3e292bc5fcfa6c396ae7a657255eef552ea7e12f996de795b90"},
+			{"ffff0f", "v_______________________7___1", "3b1ca154ec2a3d96d8d77bddef0abfe40a53a64eb03cecf78da9ec43799fa3d0"},
+			{"ffffff", "v_______________________7___2", "e75463041f1be8252781be0ace579a44ea4387bf5b2739f4607af676f7719678"},
+		},
+		{ // ff{0:f{0:f, f:f}, f:fcc}
+			{"ff0f0f", "v_______________________8___0", "0928af9b14718ec8262ab89df430f1e5fbf66fac0fed037aff2b6767ae8c8684"},
+			{"ff0fff", "v_______________________8___1", "d870f4d3ce26b0bf86912810a1960693630c20a48ba56be0ad04bc3e9ddb01e6"},
+			{"ffffcc", "v_______________________8___2", "4239f10dd9d9915ecf2e047d6a576bdc1733ed77a30830f1bf29deaf7d8e966f"},
+		},
+		{
+			{"123d", "x___________________________0", "fc453d88b6f128a77c448669710497380fa4588abbea9f78f4c20c80daa797d0"},
+			{"123e", "x___________________________1", "5af48f2d8a9a015c1ff7fa8b8c7f6b676233bd320e8fb57fd7933622badd2cec"},
+			{"123f", "x___________________________2", "1164d7299964e74ac40d761f9189b2a3987fae959800d0f7e29d3aaf3eae9e15"},
+		},
+		{
+			{"123d", "x___________________________0", "fc453d88b6f128a77c448669710497380fa4588abbea9f78f4c20c80daa797d0"},
+			{"123e", "x___________________________1", "5af48f2d8a9a015c1ff7fa8b8c7f6b676233bd320e8fb57fd7933622badd2cec"},
+			{"124a", "x___________________________2", "661a96a669869d76b7231380da0649d013301425fbea9d5c5fae6405aa31cfce"},
+		},
+		{
+			{"123d", "x___________________________0", "fc453d88b6f128a77c448669710497380fa4588abbea9f78f4c20c80daa797d0"},
+			{"123e", "x___________________________1", "5af48f2d8a9a015c1ff7fa8b8c7f6b676233bd320e8fb57fd7933622badd2cec"},
+			{"13aa", "x___________________________2", "6590120e1fd3ffd1a90e8de5bb10750b61079bb0776cca4414dd79a24e4d4356"},
+		},
+		{
+			{"123d", "x___________________________0", "fc453d88b6f128a77c448669710497380fa4588abbea9f78f4c20c80daa797d0"},
+			{"123e", "x___________________________1", "5af48f2d8a9a015c1ff7fa8b8c7f6b676233bd320e8fb57fd7933622badd2cec"},
+			{"2aaa", "x___________________________2", "f869b40e0c55eace1918332ef91563616fbf0755e2b946119679f7ef8e44b514"},
+		},
+		{
+			{"1234da", "x___________________________0", "1c4b4462e9f56a80ca0f5d77c0d632c41b0102290930343cf1791e971a045a79"},
+			{"1234ea", "x___________________________1", "2f502917f3ba7d328c21c8b45ee0f160652e68450332c166d4ad02d1afe31862"},
+			{"1234fa", "x___________________________2", "4f4e368ab367090d5bc3dbf25f7729f8bd60df84de309b4633a6b69ab66142c0"},
+		},
+		{
+			{"1234da", "x___________________________0", "1c4b4462e9f56a80ca0f5d77c0d632c41b0102290930343cf1791e971a045a79"},
+			{"1234ea", "x___________________________1", "2f502917f3ba7d328c21c8b45ee0f160652e68450332c166d4ad02d1afe31862"},
+			{"1235aa", "x___________________________2", "21840121d11a91ac8bbad9a5d06af902a5c8d56a47b85600ba813814b7bfcb9b"},
+		},
+		{
+			{"1234da", "x___________________________0", "1c4b4462e9f56a80ca0f5d77c0d632c41b0102290930343cf1791e971a045a79"},
+			{"1234ea", "x___________________________1", "2f502917f3ba7d328c21c8b45ee0f160652e68450332c166d4ad02d1afe31862"},
+			{"124aaa", "x___________________________2", "ea4040ddf6ae3fbd1524bdec19c0ab1581015996262006632027fa5cf21e441e"},
+		},
+		{
+			{"1234da", "x___________________________0", "1c4b4462e9f56a80ca0f5d77c0d632c41b0102290930343cf1791e971a045a79"},
+			{"1234ea", "x___________________________1", "2f502917f3ba7d328c21c8b45ee0f160652e68450332c166d4ad02d1afe31862"},
+			{"13aaaa", "x___________________________2", "e4beb66c67e44f2dd8ba36036e45a44ff68f8d52942472b1911a45f886a34507"},
+		},
+		{
+			{"1234da", "x___________________________0", "1c4b4462e9f56a80ca0f5d77c0d632c41b0102290930343cf1791e971a045a79"},
+			{"1234ea", "x___________________________1", "2f502917f3ba7d328c21c8b45ee0f160652e68450332c166d4ad02d1afe31862"},
+			{"2aaaaa", "x___________________________2", "5f5989b820ff5d76b7d49e77bb64f26602294f6c42a1a3becc669cd9e0dc8ec9"},
+		},
+		{
+			{"000000", "x___________________________0", "3b32b7af0bddc7940e7364ee18b5a59702c1825e469452c8483b9c4e0218b55a"},
+			{"1234da", "x___________________________1", "3ab152a1285dca31945566f872c1cc2f17a770440eda32aeee46a5e91033dde2"},
+			{"1234ea", "x___________________________2", "0cccc87f96ddef55563c1b3be3c64fff6a644333c3d9cd99852cb53b6412b9b8"},
+			{"1234fa", "x___________________________3", "65bb3aafea8121111d693ffe34881c14d27b128fd113fa120961f251fe28428d"},
+		},
+		{
+			{"000000", "x___________________________0", "3b32b7af0bddc7940e7364ee18b5a59702c1825e469452c8483b9c4e0218b55a"},
+			{"1234da", "x___________________________1", "3ab152a1285dca31945566f872c1cc2f17a770440eda32aeee46a5e91033dde2"},
+			{"1234ea", "x___________________________2", "0cccc87f96ddef55563c1b3be3c64fff6a644333c3d9cd99852cb53b6412b9b8"},
+			{"1235aa", "x___________________________3", "f670e4d2547c533c5f21e0045442e2ecb733f347ad6d29ef36e0f5ba31bb11a8"},
+		},
+		{
+			{"000000", "x___________________________0", "3b32b7af0bddc7940e7364ee18b5a59702c1825e469452c8483b9c4e0218b55a"},
+			{"1234da", "x___________________________1", "3ab152a1285dca31945566f872c1cc2f17a770440eda32aeee46a5e91033dde2"},
+			{"1234ea", "x___________________________2", "0cccc87f96ddef55563c1b3be3c64fff6a644333c3d9cd99852cb53b6412b9b8"},
+			{"124aaa", "x___________________________3", "c17464123050a9a6f29b5574bb2f92f6d305c1794976b475b7fb0316b6335598"},
+		},
+		{
+			{"000000", "x___________________________0", "3b32b7af0bddc7940e7364ee18b5a59702c1825e469452c8483b9c4e0218b55a"},
+			{"1234da", "x___________________________1", "3ab152a1285dca31945566f872c1cc2f17a770440eda32aeee46a5e91033dde2"},
+			{"1234ea", "x___________________________2", "0cccc87f96ddef55563c1b3be3c64fff6a644333c3d9cd99852cb53b6412b9b8"},
+			{"13aaaa", "x___________________________3", "aa8301be8cb52ea5cd249f5feb79fb4315ee8de2140c604033f4b3fff78f0105"},
+		},
+		{
+			{"0000", "x___________________________0", "cb8c09ad07ae882136f602b3f21f8733a9f5a78f1d2525a8d24d1c13258000b2"},
+			{"123d", "x___________________________1", "8f09663deb02f08958136410dc48565e077f76bb6c9d8c84d35fc8913a657d31"},
+			{"123e", "x___________________________2", "0d230561e398c579e09a9f7b69ceaf7d3970f5a436fdb28b68b7a37c5bdd6b80"},
+			{"123f", "x___________________________3", "80f7bad1893ca57e3443bb3305a517723a74d3ba831bcaca22a170645eb7aafb"},
+		},
+		{
+			{"0000", "x___________________________0", "cb8c09ad07ae882136f602b3f21f8733a9f5a78f1d2525a8d24d1c13258000b2"},
+			{"123d", "x___________________________1", "8f09663deb02f08958136410dc48565e077f76bb6c9d8c84d35fc8913a657d31"},
+			{"123e", "x___________________________2", "0d230561e398c579e09a9f7b69ceaf7d3970f5a436fdb28b68b7a37c5bdd6b80"},
+			{"124a", "x___________________________3", "383bc1bb4f019e6bc4da3751509ea709b58dd1ac46081670834bae072f3e9557"},
+		},
+		{
+			{"0000", "x___________________________0", "cb8c09ad07ae882136f602b3f21f8733a9f5a78f1d2525a8d24d1c13258000b2"},
+			{"123d", "x___________________________1", "8f09663deb02f08958136410dc48565e077f76bb6c9d8c84d35fc8913a657d31"},
+			{"123e", "x___________________________2", "0d230561e398c579e09a9f7b69ceaf7d3970f5a436fdb28b68b7a37c5bdd6b80"},
+			{"13aa", "x___________________________3", "ff0dc70ce2e5db90ee42a4c2ad12139596b890e90eb4e16526ab38fa465b35cf"},
+		},
+	}
+	st := NewStackTrie(nil)
+	for i, test := range tests {
+		// The StackTrie does not allow Insert(), Hash(), Insert(), ...
+		// so we will create new trie for every sequence length of inserts.
+		for l := 1; l <= len(test); l++ {
+			st.Reset()
+			for j := 0; j < l; j++ {
+				kv := &test[j]
+				if err := st.TryUpdate(common.FromHex(kv.K), []byte(kv.V)); err != nil {
+					t.Fatal(err)
+				}
+			}
+			expected := common.HexToHash(test[l-1].H)
+			if h := st.Hash(); h != expected {
+				t.Errorf("%d(%d): root hash mismatch: %x, expected %x", i, l, h, expected)
+			}
+		}
+	}
+}
+
+func TestSizeBug(t *testing.T) {
+	st := NewStackTrie(nil)
+	nt := NewEmpty(NewDatabase(storage.NewMemoryDatabase().DB()))
+
+	leaf := common.FromHex("290decd9548b62a8d60345a988386fc84ba6bc95484008f6362f93160ef3e563")
+	value := common.FromHex("94cf40d0d2b44f2b66e07cace1372ca42b73cf21a3")
+
+	nt.TryUpdate(leaf, value)
+	st.TryUpdate(leaf, value)
+
+	if nt.Hash() != st.Hash() {
+		t.Fatalf("error %x != %x", st.Hash(), nt.Hash())
+	}
+}
+
+func TestEmptyBug(t *testing.T) {
+	st := NewStackTrie(nil)
+	nt := NewEmpty(NewDatabase(storage.NewMemoryDatabase().DB()))
+
+	//leaf := common.FromHex("290decd9548b62a8d60345a988386fc84ba6bc95484008f6362f93160ef3e563")
+	//value := common.FromHex("94cf40d0d2b44f2b66e07cace1372ca42b73cf21a3")
+	kvs := []struct {
+		K string
+		V string
+	}{
+		{K: "405787fa12a823e0f2b7631cc41b3ba8828b3321ca811111fa75cd3aa3bb5ace", V: "9496f4ec2bf9dab484cac6be589e8417d84781be08"},
+		{K: "40edb63a35fcf86c08022722aa3287cdd36440d671b4918131b2514795fefa9c", V: "01"},
+		{K: "b10e2d527612073b26eecdfd717e6a320cf44b4afac2b0732d9fcbe2b7fa0cf6", V: "947a30f7736e48d6599356464ba4c150d8da0302ff"},
+		{K: "c2575a0e9e593c00f959f8c92f12db2869c3395a3b0502d05e2516446f71f85b", V: "02"},
+	}
+
+	for _, kv := range kvs {
+		nt.TryUpdate(common.FromHex(kv.K), common.FromHex(kv.V))
+		st.TryUpdate(common.FromHex(kv.K), common.FromHex(kv.V))
+	}
+
+	if nt.Hash() != st.Hash() {
+		t.Fatalf("error %x != %x", st.Hash(), nt.Hash())
+	}
+}
+
+func TestValLength56(t *testing.T) {
+	st := NewStackTrie(nil)
+	nt := NewEmpty(NewDatabase(storage.NewMemoryDatabase().DB()))
+
+	//leaf := common.FromHex("290decd9548b62a8d60345a988386fc84ba6bc95484008f6362f93160ef3e563")
+	//value := common.FromHex("94cf40d0d2b44f2b66e07cace1372ca42b73cf21a3")
+	kvs := []struct {
+		K string
+		V string
+	}{
+		{K: "405787fa12a823e0f2b7631cc41b3ba8828b3321ca811111fa75cd3aa3bb5ace", V: "1111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111"},
+	}
+
+	for _, kv := range kvs {
+		nt.TryUpdate(common.FromHex(kv.K), common.FromHex(kv.V))
+		st.TryUpdate(common.FromHex(kv.K), common.FromHex(kv.V))
+	}
+
+	if nt.Hash() != st.Hash() {
+		t.Fatalf("error %x != %x", st.Hash(), nt.Hash())
+	}
+}
+
+// TestUpdateSmallNodes tests a case where the leaves are small (both key and value),
+// which causes a lot of node-within-node. This case was found via fuzzing.
+func TestUpdateSmallNodes(t *testing.T) {
+	st := NewStackTrie(nil)
+	nt := NewEmpty(NewDatabase(storage.NewMemoryDatabase().DB()))
+
+	kvs := []struct {
+		K string
+		V string
+	}{
+		{"63303030", "3041"}, // stacktrie.Update
+		{"65", "3000"},       // stacktrie.Update
+	}
+	for _, kv := range kvs {
+		nt.TryUpdate(common.FromHex(kv.K), common.FromHex(kv.V))
+		st.TryUpdate(common.FromHex(kv.K), common.FromHex(kv.V))
+	}
+	if nt.Hash() != st.Hash() {
+		t.Fatalf("error %x != %x", st.Hash(), nt.Hash())
+	}
+}
+
+// TestUpdateVariableKeys contains a case which stacktrie fails: when keys of different
+// sizes are used, and the second one has the same prefix as the first, then the
+// stacktrie fails, since it's unable to 'expand' on an already added leaf.
+// For all practical purposes, this is fine, since keys are fixed-size length
+// in account and storage tries.
+//
+// The test is marked as 'skipped', and exists just to have the behaviour documented.
+// This case was found via fuzzing.
+func TestUpdateVariableKeys(t *testing.T) {
+	t.SkipNow()
+	st := NewStackTrie(nil)
+	nt := NewEmpty(NewDatabase(storage.NewMemoryDatabase().DB()))
+
+	kvs := []struct {
+		K string
+		V string
+	}{
+		{"0x33303534636532393561313031676174", "303030"},
+		{"0x3330353463653239356131303167617430", "313131"},
+	}
+	for _, kv := range kvs {
+		nt.TryUpdate(common.FromHex(kv.K), common.FromHex(kv.V))
+		st.TryUpdate(common.FromHex(kv.K), common.FromHex(kv.V))
+	}
+	if nt.Hash() != st.Hash() {
+		t.Fatalf("error %x != %x", st.Hash(), nt.Hash())
+	}
+}
+
+// TestStacktrieNotModifyValues checks that inserting blobs of data into the
+// stacktrie does not mutate the blobs
+func TestStacktrieNotModifyValues(t *testing.T) {
+	st := NewStackTrie(nil)
+	{ // Test a very small trie
+		// Give it the value as a slice with large backing alloc,
+		// so if the stacktrie tries to append, it won't have to realloc
+		value := make([]byte, 1, 100)
+		value[0] = 0x2
+		want := common.CopyBytes(value)
+		st.TryUpdate([]byte{0x01}, value)
+		st.Hash()
+		if have := value; !bytes.Equal(have, want) {
+			t.Fatalf("tiny trie: have %#x want %#x", have, want)
+		}
+		st = NewStackTrie(nil)
+	}
+	// Test with a larger trie
+	keyB := big.NewInt(1)
+	keyDelta := big.NewInt(1)
+	var vals [][]byte
+	getValue := func(i int) []byte {
+		if i%2 == 0 { // large
+			return crypto.Keccak256(big.NewInt(int64(i)).Bytes())
+		} else { //small
+			return big.NewInt(int64(i)).Bytes()
+		}
+	}
+	for i := 0; i < 1000; i++ {
+		key := common.BigToHash(keyB)
+		value := getValue(i)
+		st.TryUpdate(key.Bytes(), value)
+		vals = append(vals, value)
+		keyB = keyB.Add(keyB, keyDelta)
+		keyDelta.Add(keyDelta, common.Big1)
+	}
+	st.Hash()
+	for i := 0; i < 1000; i++ {
+		want := getValue(i)
+
+		have := vals[i]
+		if !bytes.Equal(have, want) {
+			t.Fatalf("item %d, have %#x want %#x", i, have, want)
+		}
+	}
+}
+
+// TestStacktrieSerialization tests that the stacktrie works well if we
+// serialize/unserialize it a lot
+func TestStacktrieSerialization(t *testing.T) {
+	var (
+		st       = NewStackTrie(nil)
+		nt       = NewEmpty(NewDatabase(storage.NewMemoryDatabase().DB()))
+		keyB     = big.NewInt(1)
+		keyDelta = big.NewInt(1)
+		vals     [][]byte
+		keys     [][]byte
+	)
+	getValue := func(i int) []byte {
+		if i%2 == 0 { // large
+			return crypto.Keccak256(big.NewInt(int64(i)).Bytes())
+		} else { //small
+			return big.NewInt(int64(i)).Bytes()
+		}
+	}
+	for i := 0; i < 10; i++ {
+		vals = append(vals, getValue(i))
+		keys = append(keys, common.BigToHash(keyB).Bytes())
+		keyB = keyB.Add(keyB, keyDelta)
+		keyDelta.Add(keyDelta, common.Big1)
+	}
+	for i, k := range keys {
+		nt.TryUpdate(k, common.CopyBytes(vals[i]))
+	}
+
+	for i, k := range keys {
+		blob, err := st.MarshalBinary()
+		if err != nil {
+			t.Fatal(err)
+		}
+		newSt, err := NewFromBinary(blob, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		st = newSt
+		st.TryUpdate(k, common.CopyBytes(vals[i]))
+	}
+	if have, want := st.Hash(), nt.Hash(); have != want {
+		t.Fatalf("have %#x want %#x", have, want)
+	}
+}

--- a/trie/stacktrie_test.go
+++ b/trie/stacktrie_test.go
@@ -22,7 +22,7 @@ import (
 	"math/big"
 	"testing"
 
-	"github.com/kardiachain/go-kardia/kai/storage"
+	"github.com/kardiachain/go-kardia/kai/kaidb/memorydb"
 	"github.com/kardiachain/go-kardia/lib/common"
 	"github.com/kardiachain/go-kardia/lib/crypto"
 )
@@ -189,7 +189,7 @@ func TestStackTrieInsertAndHash(t *testing.T) {
 
 func TestSizeBug(t *testing.T) {
 	st := NewStackTrie(nil)
-	nt := NewEmpty(NewDatabase(storage.NewMemoryDatabase().DB()))
+	nt := NewEmpty(NewDatabase(memorydb.New()))
 
 	leaf := common.FromHex("290decd9548b62a8d60345a988386fc84ba6bc95484008f6362f93160ef3e563")
 	value := common.FromHex("94cf40d0d2b44f2b66e07cace1372ca42b73cf21a3")
@@ -204,7 +204,7 @@ func TestSizeBug(t *testing.T) {
 
 func TestEmptyBug(t *testing.T) {
 	st := NewStackTrie(nil)
-	nt := NewEmpty(NewDatabase(storage.NewMemoryDatabase().DB()))
+	nt := NewEmpty(NewDatabase(memorydb.New()))
 
 	//leaf := common.FromHex("290decd9548b62a8d60345a988386fc84ba6bc95484008f6362f93160ef3e563")
 	//value := common.FromHex("94cf40d0d2b44f2b66e07cace1372ca42b73cf21a3")
@@ -230,7 +230,7 @@ func TestEmptyBug(t *testing.T) {
 
 func TestValLength56(t *testing.T) {
 	st := NewStackTrie(nil)
-	nt := NewEmpty(NewDatabase(storage.NewMemoryDatabase().DB()))
+	nt := NewEmpty(NewDatabase(memorydb.New()))
 
 	//leaf := common.FromHex("290decd9548b62a8d60345a988386fc84ba6bc95484008f6362f93160ef3e563")
 	//value := common.FromHex("94cf40d0d2b44f2b66e07cace1372ca42b73cf21a3")
@@ -255,7 +255,7 @@ func TestValLength56(t *testing.T) {
 // which causes a lot of node-within-node. This case was found via fuzzing.
 func TestUpdateSmallNodes(t *testing.T) {
 	st := NewStackTrie(nil)
-	nt := NewEmpty(NewDatabase(storage.NewMemoryDatabase().DB()))
+	nt := NewEmpty(NewDatabase(memorydb.New()))
 
 	kvs := []struct {
 		K string
@@ -284,7 +284,7 @@ func TestUpdateSmallNodes(t *testing.T) {
 func TestUpdateVariableKeys(t *testing.T) {
 	t.SkipNow()
 	st := NewStackTrie(nil)
-	nt := NewEmpty(NewDatabase(storage.NewMemoryDatabase().DB()))
+	nt := NewEmpty(NewDatabase(memorydb.New()))
 
 	kvs := []struct {
 		K string
@@ -354,7 +354,7 @@ func TestStacktrieNotModifyValues(t *testing.T) {
 func TestStacktrieSerialization(t *testing.T) {
 	var (
 		st       = NewStackTrie(nil)
-		nt       = NewEmpty(NewDatabase(storage.NewMemoryDatabase().DB()))
+		nt       = NewEmpty(NewDatabase(memorydb.New()))
 		keyB     = big.NewInt(1)
 		keyDelta = big.NewInt(1)
 		vals     [][]byte

--- a/trie/trie.go
+++ b/trie/trie.go
@@ -82,6 +82,12 @@ func New(root common.Hash, db *TrieDatabase) (*Trie, error) {
 	return trie, nil
 }
 
+// NewEmpty is a shortcut to create empty tree. It's mostly used in tests.
+func NewEmpty(db *TrieDatabase) *Trie {
+	tr, _ := New(common.Hash{}, db)
+	return tr
+}
+
 // NodeIterator returns an iterator that returns nodes of the trie. Iteration starts at
 // the key after the given start key.
 func (t *Trie) NodeIterator(start []byte) NodeIterator {
@@ -472,6 +478,12 @@ func (t *Trie) hashRoot(db *TrieDatabase) (node, node, error) {
 	hashed, cached := h.hash(t.root, true)
 	t.unhashed = 0
 	return hashed, cached, nil
+}
+
+// Reset drops the referenced root node and cleans all internal state.
+func (t *Trie) Reset() {
+	t.root = nil
+	t.unhashed = 0
 }
 
 // MissingNodeError is returned by the trie functions (TryGet, TryUpdate, TryDelete)

--- a/trie/trie_database.go
+++ b/trie/trie_database.go
@@ -164,11 +164,7 @@ func (n *cachedNode) rlp() []byte {
 	if node, ok := n.node.(rawNode); ok {
 		return node
 	}
-	blob, err := rlp.EncodeToBytes(n.node)
-	if err != nil {
-		panic(err)
-	}
-	return blob
+	return nodeToBytes(n.node)
 }
 
 // obj returns the decoded and expanded trie node, either directly from the cache,

--- a/trie/trie_test.go
+++ b/trie/trie_test.go
@@ -29,10 +29,11 @@ import (
 	"testing/quick"
 
 	"github.com/davecgh/go-spew/spew"
-	"github.com/kardiachain/go-kardia/lib/common"
-	"github.com/kardiachain/go-kardia/lib/crypto"
+
 	"github.com/kardiachain/go-kardia/kai/kaidb/leveldb"
 	"github.com/kardiachain/go-kardia/kai/kaidb/memorydb"
+	"github.com/kardiachain/go-kardia/lib/common"
+	"github.com/kardiachain/go-kardia/lib/crypto"
 	"github.com/kardiachain/go-kardia/lib/rlp"
 )
 

--- a/types/block.go
+++ b/types/block.go
@@ -593,7 +593,7 @@ func (b *Block) ToProto() (*kproto.Block, error) {
 
 // FromProto sets a protobuf Block to the given pointer.
 // It returns an error if the block is invalid.
-func BlockFromProto(bp *kproto.Block) (*Block, error) {
+func BlockFromProto(bp *kproto.Block, hasher TrieHasher) (*Block, error) {
 	if bp == nil {
 		return nil, errors.New("nil block")
 	}
@@ -622,7 +622,7 @@ func BlockFromProto(bp *kproto.Block) (*Block, error) {
 		b.lastCommit = lc
 	}
 
-	return b, b.ValidateBasic(nil)
+	return b, b.ValidateBasic(hasher)
 }
 
 type BlockID struct {

--- a/types/block_test.go
+++ b/types/block_test.go
@@ -66,7 +66,7 @@ func createHeaderRandom() *Header {
 
 func TestBlockCreation(t *testing.T) {
 	block := CreateNewBlock(1)
-	if err := block.ValidateBasic(); err != nil {
+	if err := block.ValidateBasic(nil); err != nil {
 		t.Fatal("Init block error", err)
 	}
 }
@@ -167,7 +167,7 @@ func CreateNewBlock(height uint64) *Block {
 }
 
 func TestBlockValidateBasic(t *testing.T) {
-	require.Error(t, (*Block)(nil).ValidateBasic())
+	require.Error(t, (*Block)(nil).ValidateBasic(nil))
 
 	addr1 := common.BytesToAddress([]byte("0x01"))
 	txs := []*Transaction{
@@ -225,7 +225,7 @@ func TestBlockValidateBasic(t *testing.T) {
 			block := NewBlock(&Header{Height: h}, txs, commit, evList, trie.NewStackTrie(nil))
 			block.header.ProposerAddress = valSet.GetProposer().Address
 			tc.malleateBlock(block)
-			err := block.ValidateBasic()
+			err := block.ValidateBasic(nil)
 			t.Log(err)
 			assert.Equal(t, tc.expErr, err != nil, "#%d: %v", i, err)
 		})

--- a/types/block_test.go
+++ b/types/block_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/kardiachain/go-kardia/lib/merkle"
 	krand "github.com/kardiachain/go-kardia/lib/rand"
 	kproto "github.com/kardiachain/go-kardia/proto/kardiachain/types"
+	"github.com/kardiachain/go-kardia/trie"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -162,7 +163,7 @@ func CreateNewBlock(height uint64) *Block {
 		Signatures: []CommitSig{vote.CommitSig(), CommitSig{}},
 	}
 	evidence := []Evidence{}
-	return NewBlock(&header, txns, lastCommit, evidence)
+	return NewBlock(&header, txns, lastCommit, evidence, trie.NewStackTrie(nil))
 }
 
 func TestBlockValidateBasic(t *testing.T) {
@@ -192,12 +193,13 @@ func TestBlockValidateBasic(t *testing.T) {
 			blk.lastCommit.hash = common.Hash{}
 		}, true},
 		{"Remove LastCommitHash", func(blk *Block) { blk.header.LastCommitHash = common.BytesToHash([]byte("something else")) }, true},
-		{"Tampered Data", func(blk *Block) {
-			blk.transactions[0] = NewTransaction(1, addr1, big.NewInt(1), 1, big.NewInt(1), []byte("something else"))
-		}, true},
-		{"Tampered DataHash", func(blk *Block) {
-			blk.header.TxHash = common.BytesToHash([]byte("txhash"))
-		}, true},
+		// TODO(trinhdn97): temporarily skip checking tx due to import cycle
+		// {"Tampered Data", func(blk *Block) {
+		// 	blk.transactions[0] = NewTransaction(1, addr1, big.NewInt(1), 1, big.NewInt(1), []byte("something else"))
+		// }, true},
+		// {"Tampered DataHash", func(blk *Block) {
+		// 	blk.header.TxHash = common.BytesToHash([]byte("txhash"))
+		// }, true},
 		{"Tampered EvidenceHash", func(blk *Block) {
 			blk.header.EvidenceHash = common.BytesToHash([]byte("EvidenceHash"))
 		}, true},
@@ -220,7 +222,7 @@ func TestBlockValidateBasic(t *testing.T) {
 		tc := tc
 		i := i
 		t.Run(tc.testName, func(t *testing.T) {
-			block := NewBlock(&Header{Height: h}, txs, commit, evList)
+			block := NewBlock(&Header{Height: h}, txs, commit, evList, trie.NewStackTrie(nil))
 			block.header.ProposerAddress = valSet.GetProposer().Address
 			tc.malleateBlock(block)
 			err := block.ValidateBasic()
@@ -238,7 +240,7 @@ func TestBlockHash(t *testing.T) {
 func TestBlockMakePartSet(t *testing.T) {
 	assert.Nil(t, (*Block)(nil).MakePartSet(2))
 
-	partSet := NewBlock(&Header{Height: 3}, []*Transaction{}, nil, nil).MakePartSet(1024)
+	partSet := NewBlock(&Header{Height: 3}, []*Transaction{}, nil, nil, trie.NewStackTrie(nil)).MakePartSet(1024)
 	assert.NotNil(t, partSet)
 	assert.EqualValues(t, 1, partSet.Total())
 }
@@ -256,7 +258,7 @@ func TestBlockMakePartSetWithEvidence(t *testing.T) {
 	ev := NewMockDuplicateVoteEvidenceWithValidator(h, time.Now(), vals[0], "block-test-chain")
 	evList := []Evidence{ev}
 
-	partSet := NewBlock(&Header{Height: 3}, []*Transaction{}, commit, evList).MakePartSet(512)
+	partSet := NewBlock(&Header{Height: 3}, []*Transaction{}, commit, evList, trie.NewStackTrie(nil)).MakePartSet(512)
 	assert.NotNil(t, partSet)
 	assert.EqualValues(t, 4, partSet.Total())
 }
@@ -273,7 +275,7 @@ func TestBlockHashesTo(t *testing.T) {
 	ev := NewMockDuplicateVoteEvidenceWithValidator(h, time.Now(), vals[0], "block-test-chain")
 	evList := []Evidence{ev}
 
-	block := NewBlock(&Header{Height: 3}, []*Transaction{}, commit, evList)
+	block := NewBlock(&Header{Height: 3}, []*Transaction{}, commit, evList, trie.NewStackTrie(nil))
 	block.header.ValidatorsHash = valSet.Hash()
 	assert.False(t, block.HashesTo(common.Hash{}))
 	assert.False(t, block.HashesTo(common.BytesToHash([]byte("something else"))))
@@ -281,7 +283,7 @@ func TestBlockHashesTo(t *testing.T) {
 }
 
 func TestBlockSize(t *testing.T) {
-	size := NewBlock(&Header{Height: 3}, []*Transaction{}, nil, nil).Size()
+	size := NewBlock(&Header{Height: 3}, []*Transaction{}, nil, nil, trie.NewStackTrie(nil)).Size()
 	if size <= 0 {
 		t.Fatal("Size of the block is zero or negative")
 	}

--- a/types/block_test.go
+++ b/types/block_test.go
@@ -193,13 +193,12 @@ func TestBlockValidateBasic(t *testing.T) {
 			blk.lastCommit.hash = common.Hash{}
 		}, true},
 		{"Remove LastCommitHash", func(blk *Block) { blk.header.LastCommitHash = common.BytesToHash([]byte("something else")) }, true},
-		// TODO(trinhdn97): temporarily skip checking tx due to import cycle
-		// {"Tampered Data", func(blk *Block) {
-		// 	blk.transactions[0] = NewTransaction(1, addr1, big.NewInt(1), 1, big.NewInt(1), []byte("something else"))
-		// }, true},
-		// {"Tampered DataHash", func(blk *Block) {
-		// 	blk.header.TxHash = common.BytesToHash([]byte("txhash"))
-		// }, true},
+		{"Tampered Data", func(blk *Block) {
+			blk.transactions[0] = NewTransaction(1, addr1, big.NewInt(1), 1, big.NewInt(1), []byte("something else"))
+		}, true},
+		{"Tampered DataHash", func(blk *Block) {
+			blk.header.TxHash = common.BytesToHash([]byte("txhash"))
+		}, true},
 		{"Tampered EvidenceHash", func(blk *Block) {
 			blk.header.EvidenceHash = common.BytesToHash([]byte("EvidenceHash"))
 		}, true},
@@ -225,7 +224,7 @@ func TestBlockValidateBasic(t *testing.T) {
 			block := NewBlock(&Header{Height: h}, txs, commit, evList, trie.NewStackTrie(nil))
 			block.header.ProposerAddress = valSet.GetProposer().Address
 			tc.malleateBlock(block)
-			err := block.ValidateBasic(nil)
+			err := block.ValidateBasic(trie.NewStackTrie(nil))
 			t.Log(err)
 			assert.Equal(t, tc.expErr, err != nil, "#%d: %v", i, err)
 		})

--- a/types/commit_test.go
+++ b/types/commit_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/kardiachain/go-kardia/lib/crypto"
 	"github.com/kardiachain/go-kardia/lib/rand"
 	kproto "github.com/kardiachain/go-kardia/proto/kardiachain/types"
+	"github.com/kardiachain/go-kardia/trie"
 )
 
 func makeBlockIDRandom() BlockID {
@@ -138,5 +139,5 @@ func CreateNewBlockWithTwoVotes(height uint64) *Block {
 		Round:      1,
 		Signatures: []CommitSig{vote.CommitSig(), NewCommitSigAbsent()},
 	}
-	return NewBlock(&header, txns, lastCommit, nil)
+	return NewBlock(&header, txns, lastCommit, nil, trie.NewStackTrie(nil))
 }

--- a/types/hashing.go
+++ b/types/hashing.go
@@ -1,0 +1,85 @@
+// Modifications Copyright 2023 The KardiaChain Authors
+// Copyright 2021 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package types
+
+import (
+	"bytes"
+	"sync"
+
+	"github.com/kardiachain/go-kardia/lib/common"
+	"github.com/kardiachain/go-kardia/lib/rlp"
+)
+
+// encodeBufferPool holds temporary encoder buffers for DeriveSha and TX encoding.
+var encodeBufferPool = sync.Pool{
+	New: func() interface{} { return new(bytes.Buffer) },
+}
+
+// TrieHasher is the tool used to calculate the hash of derivable list.
+// This is internal, do not use.
+type TrieHasher interface {
+	Reset()
+	Update([]byte, []byte)
+	Hash() common.Hash
+}
+
+// DerivableList is the input to DeriveSha.
+// It is implemented by the 'Transactions' and 'Receipts' types.
+// This is internal, do not use these methods.
+type DerivableList interface {
+	Len() int
+	EncodeIndex(int, *bytes.Buffer)
+}
+
+func encodeForDerive(list DerivableList, i int, buf *bytes.Buffer) []byte {
+	buf.Reset()
+	list.EncodeIndex(i, buf)
+	// It's really unfortunate that we need to do perform this copy.
+	// StackTrie holds onto the values until Hash is called, so the values
+	// written to it must not alias.
+	return common.CopyBytes(buf.Bytes())
+}
+
+// DeriveSha creates the tree hashes of transactions and receipts in a block header.
+func DeriveSha(list DerivableList, hasher TrieHasher) common.Hash {
+	hasher.Reset()
+
+	valueBuf := encodeBufferPool.Get().(*bytes.Buffer)
+	defer encodeBufferPool.Put(valueBuf)
+
+	// StackTrie requires values to be inserted in increasing hash order, which is not the
+	// order that `list` provides hashes in. This insertion sequence ensures that the
+	// order is correct.
+	var indexBuf []byte
+	for i := 1; i < list.Len() && i <= 0x7f; i++ {
+		indexBuf = rlp.AppendUint64(indexBuf[:0], uint64(i))
+		value := encodeForDerive(list, i, valueBuf)
+		hasher.Update(indexBuf, value)
+	}
+	if list.Len() > 0 {
+		indexBuf = rlp.AppendUint64(indexBuf[:0], 0)
+		value := encodeForDerive(list, 0, valueBuf)
+		hasher.Update(indexBuf, value)
+	}
+	for i := 0x80; i < list.Len(); i++ {
+		indexBuf = rlp.AppendUint64(indexBuf[:0], uint64(i))
+		value := encodeForDerive(list, i, valueBuf)
+		hasher.Update(indexBuf, value)
+	}
+	return hasher.Hash()
+}

--- a/types/hashing_test.go
+++ b/types/hashing_test.go
@@ -1,0 +1,228 @@
+// Modifications Copyright 2023 The KardiaChain Authors
+// Copyright 2021 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package types_test
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"math/big"
+	mrand "math/rand"
+	"testing"
+
+	"github.com/kardiachain/go-kardia/kai/storage"
+	"github.com/kardiachain/go-kardia/lib/common"
+	"github.com/kardiachain/go-kardia/lib/crypto"
+	"github.com/kardiachain/go-kardia/lib/rlp"
+	"github.com/kardiachain/go-kardia/trie"
+	"github.com/kardiachain/go-kardia/types"
+)
+
+func TestDeriveSha(t *testing.T) {
+	txs, err := genTxs(0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for len(txs) < 1000 {
+		exp := types.DeriveSha(txs, trie.NewEmpty(trie.NewDatabase(storage.NewMemoryDatabase().DB())))
+		got := types.DeriveSha(txs, trie.NewStackTrie(nil))
+		if !bytes.Equal(got[:], exp[:]) {
+			t.Fatalf("%d txs: got %x exp %x", len(txs), got, exp)
+		}
+		newTxs, err := genTxs(uint64(len(txs) + 1))
+		if err != nil {
+			t.Fatal(err)
+		}
+		txs = append(txs, newTxs...)
+	}
+}
+
+// TestEIP2718DeriveSha tests that the input to the DeriveSha function is correct.
+func TestEIP2718DeriveSha(t *testing.T) {
+	for _, tc := range []struct {
+		rlpData string
+		exp     string
+	}{
+		{
+			rlpData: "0xf86103018207d094b94f5374fce5edbc8e2a8697c15331677e6ebf0b0a8255441ca098ff921201554726367d2be8c804a7ff89ccf285ebc57dff8ae4c44b9c19ac4aa08887321be575c8095f789dd4c743dfe42c1820f9231f98a962b210e3ac2452a3",
+			exp:     "01 f86103018207d094b94f5374fce5edbc8e2a8697c15331677e6ebf0b0a8255441ca098ff921201554726367d2be8c804a7ff89ccf285ebc57dff8ae4c44b9c19ac4aa08887321be575c8095f789dd4c743dfe42c1820f9231f98a962b210e3ac2452a3\n80 f86103018207d094b94f5374fce5edbc8e2a8697c15331677e6ebf0b0a8255441ca098ff921201554726367d2be8c804a7ff89ccf285ebc57dff8ae4c44b9c19ac4aa08887321be575c8095f789dd4c743dfe42c1820f9231f98a962b210e3ac2452a3\n",
+		},
+	} {
+		d := &hashToHumanReadable{}
+		var t1, t2 types.Transaction
+		rlp.DecodeBytes(common.FromHex(tc.rlpData), &t1)
+		rlp.DecodeBytes(common.FromHex(tc.rlpData), &t2)
+		txs := types.Transactions{&t1, &t2}
+		types.DeriveSha(txs, d)
+		if tc.exp != string(d.data) {
+			t.Fatalf("Want\n%v\nhave:\n%v", tc.exp, string(d.data))
+		}
+	}
+}
+
+func BenchmarkDeriveSha200(b *testing.B) {
+	txs, err := genTxs(200)
+	if err != nil {
+		b.Fatal(err)
+	}
+	var exp common.Hash
+	var got common.Hash
+	b.Run("std_trie", func(b *testing.B) {
+		b.ResetTimer()
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			exp = types.DeriveSha(txs, trie.NewEmpty(trie.NewDatabase(storage.NewMemoryDatabase().DB())))
+		}
+	})
+
+	b.Run("stack_trie", func(b *testing.B) {
+		b.ResetTimer()
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			got = types.DeriveSha(txs, trie.NewStackTrie(nil))
+		}
+	})
+	if got != exp {
+		b.Errorf("got %x exp %x", got, exp)
+	}
+}
+
+func TestFuzzDeriveSha(t *testing.T) {
+	// increase this for longer runs -- it's set to quite low for travis
+	rndSeed := mrand.Int()
+	for i := 0; i < 10; i++ {
+		seed := rndSeed + i
+		exp := types.DeriveSha(newDummy(i), trie.NewEmpty(trie.NewDatabase(storage.NewMemoryDatabase().DB())))
+		got := types.DeriveSha(newDummy(i), trie.NewStackTrie(nil))
+		if !bytes.Equal(got[:], exp[:]) {
+			// printList(newDummy(seed))
+			t.Fatalf("seed %d: got %x exp %x", seed, got, exp)
+		}
+	}
+}
+
+// TestDerivableList contains testcases found via fuzzing
+func TestDerivableList(t *testing.T) {
+	type tcase []string
+	tcs := []tcase{
+		{
+			"0xc041",
+		},
+		{
+			"0xf04cf757812428b0763112efb33b6f4fad7deb445e",
+			"0xf04cf757812428b0763112efb33b6f4fad7deb445e",
+		},
+		{
+			"0xca410605310cdc3bb8d4977ae4f0143df54a724ed873457e2272f39d66e0460e971d9d",
+			"0x6cd850eca0a7ac46bb1748d7b9cb88aa3bd21c57d852c28198ad8fa422c4595032e88a4494b4778b36b944fe47a52b8c5cd312910139dfcb4147ab8e972cc456bcb063f25dd78f54c4d34679e03142c42c662af52947d45bdb6e555751334ace76a5080ab5a0256a1d259855dfc5c0b8023b25befbb13fd3684f9f755cbd3d63544c78ee2001452dd54633a7593ade0b183891a0a4e9c7844e1254005fbe592b1b89149a502c24b6e1dca44c158aebedf01beae9c30cabe16a",
+			"0x14abd5c47c0be87b0454596baad2",
+			"0xca410605310cdc3bb8d4977ae4f0143df54a724ed873457e2272f39d66e0460e971d9d",
+		},
+	}
+	for i, tc := range tcs[1:] {
+		exp := types.DeriveSha(flatList(tc), trie.NewEmpty(trie.NewDatabase(storage.NewMemoryDatabase().DB())))
+		got := types.DeriveSha(flatList(tc), trie.NewStackTrie(nil))
+		if !bytes.Equal(got[:], exp[:]) {
+			t.Fatalf("case %d: got %x exp %x", i, got, exp)
+		}
+	}
+}
+
+func genTxs(num uint64) (types.Transactions, error) {
+	key, err := crypto.HexToECDSA("deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef")
+	if err != nil {
+		return nil, err
+	}
+	var addr = crypto.PubkeyToAddress(key.PublicKey)
+	newTx := func(i uint64) (*types.Transaction, error) {
+		utx := types.NewTransaction(i, addr, new(big.Int), 0, new(big.Int).SetUint64(10000000), nil)
+		tx, err := types.SignTx(types.HomesteadSigner{}, utx, key)
+		return tx, err
+	}
+	var txs types.Transactions
+	for i := uint64(0); i < num; i++ {
+		tx, err := newTx(i)
+		if err != nil {
+			return nil, err
+		}
+		txs = append(txs, tx)
+	}
+	return txs, nil
+}
+
+type dummyDerivableList struct {
+	len  int
+	seed int
+}
+
+func newDummy(seed int) *dummyDerivableList {
+	d := &dummyDerivableList{}
+	src := mrand.NewSource(int64(seed))
+	// don't use lists longer than 4K items
+	d.len = int(src.Int63() & 0x0FFF)
+	d.seed = seed
+	return d
+}
+
+func (d *dummyDerivableList) Len() int {
+	return d.len
+}
+
+func (d *dummyDerivableList) EncodeIndex(i int, w *bytes.Buffer) {
+	src := mrand.NewSource(int64(d.seed + i))
+	// max item size 256, at least 1 byte per item
+	size := 1 + src.Int63()&0x00FF
+	io.CopyN(w, mrand.New(src), size)
+}
+
+func printList(l types.DerivableList) {
+	fmt.Printf("list length: %d\n", l.Len())
+	fmt.Printf("{\n")
+	for i := 0; i < l.Len(); i++ {
+		var buf bytes.Buffer
+		l.EncodeIndex(i, &buf)
+		fmt.Printf("\"%#x\",\n", buf.Bytes())
+	}
+	fmt.Printf("},\n")
+}
+
+type flatList []string
+
+func (f flatList) Len() int {
+	return len(f)
+}
+func (f flatList) EncodeIndex(i int, w *bytes.Buffer) {
+	w.Write(common.MustDecode(f[i]))
+}
+
+type hashToHumanReadable struct {
+	data []byte
+}
+
+func (d *hashToHumanReadable) Reset() {
+	d.data = make([]byte, 0)
+}
+
+func (d *hashToHumanReadable) Update(i []byte, i2 []byte) {
+	l := fmt.Sprintf("%x %x\n", i, i2)
+	d.data = append(d.data, []byte(l)...)
+}
+
+func (d *hashToHumanReadable) Hash() common.Hash {
+	return common.Hash{}
+}

--- a/types/transaction.go
+++ b/types/transaction.go
@@ -19,6 +19,7 @@
 package types
 
 import (
+	"bytes"
 	"container/heap"
 	"crypto/ecdsa"
 	"errors"
@@ -191,7 +192,6 @@ func (tx *Transaction) Size() common.StorageSize {
 }
 
 // AsMessage returns the transaction as a core.Message.
-//
 func (tx *Transaction) AsMessage(s Signer) (Message, error) {
 	msg := Message{
 		nonce:      tx.data.AccountNonce,
@@ -253,6 +253,13 @@ type Transactions []*Transaction
 // Len returns the length of s.
 func (s Transactions) Len() int { return len(s) }
 
+// EncodeIndex encodes the i'th transaction to w. Note that this does not check for errors
+// because we assume that *Transaction will only ever contain valid txs that were either
+// constructed by decoding or via public API in this package.
+func (s Transactions) EncodeIndex(i int, w *bytes.Buffer) {
+	rlp.Encode(w, s[i].data)
+}
+
 // Empty returns whether the list of transactions is empty or not.
 func (s Transactions) Empty() bool {
 	return s.Len() == 0
@@ -267,8 +274,8 @@ func (s Transactions) GetRlp(i int) []byte {
 	return enc
 }
 
-func (s Transactions) Hash() common.Hash {
-	return DeriveSha(s)
+func (s Transactions) Hash(hasher TrieHasher) common.Hash {
+	return DeriveSha(s, hasher)
 }
 
 // Contains tells whether contains hash.

--- a/types/transaction_test.go
+++ b/types/transaction_test.go
@@ -69,6 +69,7 @@ func TestTransactionEncode(t *testing.T) {
 		t.Fatalf("encode error: %v", err)
 	}
 	should := common.FromHex("f86103018207d094b94f5374fce5edbc8e2a8697c15331677e6ebf0b0a8255441ca098ff921201554726367d2be8c804a7ff89ccf285ebc57dff8ae4c44b9c19ac4aa08887321be575c8095f789dd4c743dfe42c1820f9231f98a962b210e3ac2452a3")
+	t.Logf(common.ToHex(should))
 	if !bytes.Equal(txb, should) {
 		t.Errorf("encoded RLP mismatch, got %x", txb)
 	}

--- a/types/transaction_test.go
+++ b/types/transaction_test.go
@@ -69,7 +69,6 @@ func TestTransactionEncode(t *testing.T) {
 		t.Fatalf("encode error: %v", err)
 	}
 	should := common.FromHex("f86103018207d094b94f5374fce5edbc8e2a8697c15331677e6ebf0b0a8255441ca098ff921201554726367d2be8c804a7ff89ccf285ebc57dff8ae4c44b9c19ac4aa08887321be575c8095f789dd4c743dfe42c1820f9231f98a962b210e3ac2452a3")
-	t.Logf(common.ToHex(should))
 	if !bytes.Equal(txb, should) {
 		t.Errorf("encoded RLP mismatch, got %x", txb)
 	}


### PR DESCRIPTION
Following https://github.com/kardiachain/go-kardia/issues/237

- [X] Implement stacktrie
- [X] Use `trie.Stacktrie` for block and transactions hashing instead of `trie.Trie` currently
```
name                      old time/op    new time/op    delta
DeriveSha200/trie-16     221µs ± 1%     209µs ± 0%   -5.39%  (p=0.000 n=20+19)

name                      old alloc/op   new alloc/op   delta
DeriveSha200/trie-16     287kB ± 0%      60kB ± 0%  -79.02%  (p=0.000 n=20+20)

name                      old allocs/op  new allocs/op  delta
DeriveSha200/trie-16     2.89k ± 0%     1.24k ± 0%  -57.10%  (p=0.000 n=20+20)
```
- [X] Optimize `DeriveSha` by exposing the RLP int-encoding and making use of it to write integers directly to a buffer
Benchmark result is using `trie.Trie` only
```
name                      old time/op    new time/op    delta
DeriveSha200/std_trie-16     241µs ± 2%     220µs ± 0%  -8.76%  (p=0.000 n=19+16)

name                      old alloc/op   new alloc/op   delta
DeriveSha200/std_trie-16     271kB ± 0%     287kB ± 0%  +5.83%  (p=0.000 n=20+20)

name                      old allocs/op  new allocs/op  delta
DeriveSha200/std_trie-16     2.69k ± 0%     2.89k ± 0%  +7.40%  (p=0.000 n=19+20)
```
- [X] Expose and use the encoder buffer for trie RLP actions
```
name                      old time/op    new time/op    delta
EncodeShortNode-16           147ns ± 9%      72ns ±10%  -51.27%  (p=0.000 n=20+20)
EncodeFullNode-16           1.56µs ±28%    0.41µs ±24%  -73.76%  (p=0.000 n=20+20)
DecodeShortNode-16           197ns ±51%     165ns ± 9%  -16.32%  (p=0.000 n=18+16)
DecodeShortNodeUnsafe-16     181ns ±45%     161ns ±20%     ~     (p=0.086 n=20+20)
DecodeFullNode-16           1.26µs ±45%    1.45µs ±33%  +14.66%  (p=0.045 n=17+20)
DecodeFullNodeUnsafe-16     1.28µs ±48%    1.23µs ±23%     ~     (p=0.473 n=20+20)

name                      old alloc/op   new alloc/op   delta
EncodeShortNode-16           48.0B ± 0%     48.0B ± 0%     ~     (all equal)
EncodeFullNode-16             864B ± 0%      576B ± 0%  -33.33%  (p=0.000 n=20+20)
DecodeShortNode-16            189B ± 0%      189B ± 0%     ~     (all equal)
DecodeShortNodeUnsafe-16      141B ± 0%      141B ± 0%     ~     (all equal)
DecodeFullNode-16           1.79kB ± 0%    1.79kB ± 0%     ~     (all equal)
DecodeFullNodeUnsafe-16     1.22kB ± 0%    1.22kB ± 0%     ~     (all equal)

name                      old allocs/op  new allocs/op  delta
EncodeShortNode-16            1.00 ± 0%      1.00 ± 0%     ~     (all equal)
EncodeFullNode-16             2.00 ± 0%      1.00 ± 0%  -50.00%  (p=0.000 n=20+20)
DecodeShortNode-16            5.00 ± 0%      5.00 ± 0%     ~     (all equal)
DecodeShortNodeUnsafe-16      4.00 ± 0%      4.00 ± 0%     ~     (all equal)
DecodeFullNode-16             34.0 ± 0%      34.0 ± 0%     ~     (all equal)
DecodeFullNodeUnsafe-16       33.0 ± 0%      33.0 ± 0%     ~     (all equal)
```