### PR TITLE
Fix timeout fetching from github

### DIFF
--- a/mainchain/blockchain/block_operations.go
+++ b/mainchain/blockchain/block_operations.go
@@ -144,7 +144,7 @@ func (bo *BlockOperations) CommitAndValidateBlockTxs(block *types.Block, lastCom
 	byzVals []stypes.Evidence) ([]*types.Validator, common.Hash, error) {
 	// Update blacklisted addresses after interval
 	if block.Height()%tx_pool.UpdateBlacklistInterval == 0 {
-		err := tx_pool.UpdateBlacklist()
+		err := tx_pool.UpdateBlacklist(tx_pool.BlacklistRequestTimeout)
 		if err != nil {
 			bo.logger.Warn("Cannot get blacklisted addresses", "err", err)
 		}

--- a/mainchain/blockchain/block_operations.go
+++ b/mainchain/blockchain/block_operations.go
@@ -146,7 +146,7 @@ func (bo *BlockOperations) CommitAndValidateBlockTxs(block *types.Block, lastCom
 	if block.Height()%tx_pool.UpdateBlacklistInterval == 0 {
 		err := tx_pool.UpdateBlacklist()
 		if err != nil {
-			bo.logger.Crit("Cannot get blacklisted addresses", "err", err)
+			bo.logger.Warn("Cannot get blacklisted addresses", "err", err)
 		}
 		bo.logger.Info("Current blacklisted addresses", "addresses", tx_pool.StringifyBlacklist())
 	}

--- a/mainchain/kardia_service.go
+++ b/mainchain/kardia_service.go
@@ -20,6 +20,8 @@
 package kai
 
 import (
+	"time"
+
 	bcReactor "github.com/kardiachain/go-kardia/blockchain"
 	"github.com/kardiachain/go-kardia/configs"
 	"github.com/kardiachain/go-kardia/consensus"
@@ -40,7 +42,6 @@ import (
 	"github.com/kardiachain/go-kardia/rpc"
 	"github.com/kardiachain/go-kardia/types"
 	"github.com/kardiachain/go-kardia/types/evidence"
-	"time"
 )
 
 // TODO: evaluates using this sub-service as dual mode or light sub-protocol.

--- a/mainchain/kardia_service.go
+++ b/mainchain/kardia_service.go
@@ -40,6 +40,7 @@ import (
 	"github.com/kardiachain/go-kardia/rpc"
 	"github.com/kardiachain/go-kardia/types"
 	"github.com/kardiachain/go-kardia/types/evidence"
+	"time"
 )
 
 // TODO: evaluates using this sub-service as dual mode or light sub-protocol.
@@ -154,7 +155,7 @@ func newKardiaService(ctx *node.ServiceContext, config *Config) (*KardiaService,
 	}
 
 	// Initialize the blacklist before starting node
-	err = tx_pool.UpdateBlacklist()
+	err = tx_pool.UpdateBlacklist(10 * time.Second)
 	if err != nil {
 		return nil, err
 	}

--- a/mainchain/kardia_service.go
+++ b/mainchain/kardia_service.go
@@ -20,8 +20,6 @@
 package kai
 
 import (
-	"time"
-
 	bcReactor "github.com/kardiachain/go-kardia/blockchain"
 	"github.com/kardiachain/go-kardia/configs"
 	"github.com/kardiachain/go-kardia/consensus"
@@ -156,7 +154,7 @@ func newKardiaService(ctx *node.ServiceContext, config *Config) (*KardiaService,
 	}
 
 	// Initialize the blacklist before starting node
-	err = tx_pool.UpdateBlacklist(10 * time.Second)
+	err = tx_pool.UpdateBlacklist(tx_pool.InitialBlacklistRequestTimeout)
 	if err != nil {
 		return nil, err
 	}

--- a/mainchain/tx_pool/tx_pool.go
+++ b/mainchain/tx_pool/tx_pool.go
@@ -54,7 +54,7 @@ const (
 
 	UpdateBlacklistInterval uint64 = 50 // blocks since last update
 	blacklistURL                   = "https://raw.githubusercontent.com/kardiachain/consensus/main/notes"
-	blacklistRequestTimeout        = 1 * time.Second
+	blacklistRequestTimeout        = 2 * time.Second
 )
 
 var (

--- a/mainchain/tx_pool/tx_pool.go
+++ b/mainchain/tx_pool/tx_pool.go
@@ -52,9 +52,10 @@ const (
 	// to validate whether they fit into the pool or not.
 	txMaxSize = 4 * txSlotSize // 128KB
 
-	UpdateBlacklistInterval uint64 = 50 // blocks since last update
-	blacklistURL                   = "https://raw.githubusercontent.com/kardiachain/consensus/main/notes"
-	BlacklistRequestTimeout        = 2 * time.Second
+	UpdateBlacklistInterval        uint64 = 50 // blocks since last update
+	blacklistURL                          = "https://raw.githubusercontent.com/kardiachain/consensus/main/notes"
+	InitialBlacklistRequestTimeout        = 1 * time.Second
+	BlacklistRequestTimeout               = 2 * time.Second
 )
 
 var (

--- a/mainchain/tx_pool/tx_pool.go
+++ b/mainchain/tx_pool/tx_pool.go
@@ -54,7 +54,7 @@ const (
 
 	UpdateBlacklistInterval uint64 = 50 // blocks since last update
 	blacklistURL                   = "https://raw.githubusercontent.com/kardiachain/consensus/main/notes"
-	blacklistRequestTimeout        = 2 * time.Second
+	BlacklistRequestTimeout        = 2 * time.Second
 )
 
 var (

--- a/mainchain/tx_pool/tx_pool_helper.go
+++ b/mainchain/tx_pool/tx_pool_helper.go
@@ -4,14 +4,15 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/kardiachain/go-kardia/lib/common"
 	"github.com/kardiachain/go-kardia/lib/log"
 )
 
 // UpdateBlacklist fetch and overwrite the current blacklist
-func UpdateBlacklist() error {
-	httpClient := http.Client{Timeout: blacklistRequestTimeout}
+func UpdateBlacklist(timeout time.Duration) error {
+	httpClient := http.Client{Timeout: timeout}
 	resp, err := httpClient.Get(blacklistURL)
 	if err != nil {
 		log.Warn("Cannot get blacklisted addresses", "err", err)


### PR DESCRIPTION
- [X] Increase default fetching timout to 2 seconds and when start node to 10 seconds
- [X] Change `log.Crit` to `log.Warn` for not halting the node if it can't fetch the blacklist in time