### PR TITLE
Bump client version to v2.1.0

### DIFF
--- a/configs/version.go
+++ b/configs/version.go
@@ -24,7 +24,7 @@ import (
 
 const (
 	VersionMajor        = 2        // Major version component of the current release
-	VersionMinor        = 0        // Minor version component of the current release
+	VersionMinor        = 1        // Minor version component of the current release
 	VersionPatch        = 0        // Patch version component of the current release
 	VersionMeta  string = "stable" // Version metadata to append to the version string
 )


### PR DESCRIPTION
This PR allow the API `web3_clientVersion` return the correct current client version.